### PR TITLE
style: removed redundant type casting

### DIFF
--- a/app/src/main/java/org/apache/fineract/ui/base/FineractBaseActivity.java
+++ b/app/src/main/java/org/apache/fineract/ui/base/FineractBaseActivity.java
@@ -43,7 +43,7 @@ public class FineractBaseActivity extends AppCompatActivity implements BaseActiv
     @Override
     public void setContentView(int layoutResID) {
         super.setContentView(layoutResID);
-        toolbar = (Toolbar) findViewById(R.id.toolbar);
+        toolbar =  findViewById(R.id.toolbar);
         if (toolbar != null) {
             setSupportActionBar(toolbar);
         }

--- a/app/src/main/java/org/apache/fineract/ui/base/Toaster.java
+++ b/app/src/main/java/org/apache/fineract/ui/base/Toaster.java
@@ -21,7 +21,7 @@ public class Toaster {
     public static void show(View view, String text, int duration) {
         final Snackbar snackbar = Snackbar.make(view, text, duration);
         View sbView = snackbar.getView();
-        TextView textView = (TextView) sbView.findViewById(android.support.design.R.id
+        TextView textView =  sbView.findViewById(android.support.design.R.id
                 .snackbar_text);
         textView.setTextColor(Color.WHITE);
         textView.setTextSize(12);
@@ -37,7 +37,7 @@ public class Toaster {
     public static void showProgressMessage(View view, String text, int duration) {
         final Snackbar snackbar = Snackbar.make(view, text, duration);
         View sbView = snackbar.getView();
-        TextView textView = (TextView) sbView.findViewById(android.support.design.R.id
+        TextView textView = sbView.findViewById(android.support.design.R.id
                 .snackbar_text);
         textView.setTextColor(Color.WHITE);
         textView.setTextSize(12);

--- a/app/src/main/java/org/apache/fineract/ui/online/DashboardActivity.java
+++ b/app/src/main/java/org/apache/fineract/ui/online/DashboardActivity.java
@@ -134,7 +134,7 @@ public class DashboardActivity extends FineractBaseActivity implements
 
     @Override
     public void onBackPressed() {
-        DrawerLayout drawer = (DrawerLayout) findViewById(R.id.drawer_layout);
+        DrawerLayout drawer =  findViewById(R.id.drawer_layout);
         if (drawer.isDrawerOpen(GravityCompat.START)) {
             drawer.closeDrawer(GravityCompat.START);
         } else {


### PR DESCRIPTION


Fixes #32

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.