### PR TITLE
Drawer layout is transparent with status bar

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -48,7 +48,8 @@
             android:name=".ui.online.login.LoginActivity"
             android:windowSoftInputMode="adjustResize" />
 
-        <activity android:name=".ui.online.DashboardActivity" />
+        <activity android:name=".ui.online.DashboardActivity"
+            android:theme="@style/AppTheme.TransparentStatusBar" />
 
         <activity android:name=".ui.online.customers.customerdetails.CustomerDetailsActivity" />
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,4 +1,4 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Base application theme. -->
     <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
@@ -13,6 +13,11 @@
         <item name="android:fontFamily">@font/roboto</item>
     </style>
 
+    <style name="AppTheme.TransparentStatusBar">
+        <item name="android:statusBarColor" tools:targetApi="lollipop">
+            @android:color/transparent
+        </item>
+    </style>
 
     <style name="AppTheme.Black" parent="Theme.AppCompat.Light.NoActionBar">
         <!-- Customize your theme here. -->


### PR DESCRIPTION
Fixes #FINCN-199

According to material design, the status bar should be transparent when the drawer layout is open.

**Note**
The navigation header background has not been changed in PR, to show the transparent clear
 I changed the color to take a screenshot only then reverted it.

![Screenshot_1582740115](https://user-images.githubusercontent.com/49963168/75388697-6e675700-590b-11ea-9813-f07c1e86c0ee.png)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.


