### PR TITLE
Fincn 200

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,7 +19,8 @@
         android:icon="@drawable/launcher_image"
         android:label="@string/app_name"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        android:usesCleartextTraffic="true">
 
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/app/src/main/java/org/apache/fineract/ui/online/customers/customerlist/CustomersFragment.java
+++ b/app/src/main/java/org/apache/fineract/ui/online/customers/customerlist/CustomersFragment.java
@@ -271,7 +271,6 @@ public class CustomersFragment extends FineractBaseFragment implements Customers
         searchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
             @Override
             public boolean onQueryTextSubmit(String query) {
-                findCustomer(query);
                 return false;
             }
 
@@ -279,6 +278,8 @@ public class CustomersFragment extends FineractBaseFragment implements Customers
             public boolean onQueryTextChange(String newText) {
                 if (TextUtils.isEmpty(newText)) {
                     customerAdapter.setCustomers(customers);
+                } else {
+                   findCustomer(newText);
                 }
 
                 return false;
@@ -311,6 +312,9 @@ public class CustomersFragment extends FineractBaseFragment implements Customers
                     Toaster.SHORT);
         } else if (rbOnline.isChecked()) {
             customerPresenter.searchCustomerOnline(query);
+        } else {
+            Toaster.show(swipeRefreshLayout, getString(R.string.error_searching_offline_customers),
+                    Toaster.SHORT);
         }
     }
 

--- a/app/src/main/java/org/apache/fineract/ui/online/customers/customerlist/CustomersFragment.java
+++ b/app/src/main/java/org/apache/fineract/ui/online/customers/customerlist/CustomersFragment.java
@@ -279,7 +279,7 @@ public class CustomersFragment extends FineractBaseFragment implements Customers
                 if (TextUtils.isEmpty(newText)) {
                     customerAdapter.setCustomers(customers);
                 } else {
-                   findCustomer(newText);
+                    findCustomer(newText);
                 }
 
                 return false;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -297,6 +297,7 @@
     <string name="error_fetching_customer_details">Failed to fetch customer details</string>
     <string name="error_fetching_deposit_product">Failed to fetch deposit product</string>
     <string name="error_failed_to_refresh_customers">Failed to refresh customers</string>
+    <string name="error_searching_offline_customers">Offline Search is not Supported as of now</string>
 
 
     <!--Material Dialog-->


### PR DESCRIPTION
Fixes #FINCN-200

**Summary**
Starting with Android 9 (API level 28), cleartext support is disabled by default. Hence, the countries list was not being fetched.
Modify AndroidManifest file to support cleartext traafic.

Reference:
[https://stackoverflow.com/questions/45940861/android-8-cleartext-http-traffic-not-permitted](url)


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.


