### PR TITLE
fix: Unable to fetch list of countries in FormCustomerAddressFragemnt

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,7 +19,8 @@
         android:icon="@drawable/launcher_image"
         android:label="@string/app_name"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        android:usesCleartextTraffic="true">
 
         <provider
             android:name="androidx.core.content.FileProvider"


### PR DESCRIPTION
Fixes #FINCN-200

**Summary**
Starting with Android 9 (API level 28), cleartext support is disabled by default and due to which list of Countries in the FormCustomerAddressFragment was not retrieved.
Modified the AndroidManifest file to support ClearText Traffic

Reference:
[https://stackoverflow.com/questions/45940861/android-8-cleartext-http-traffic-not-permitted](url)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [X] Run the unit tests with `./gradlew check` to make sure you didn't break anything.

- [X] If you have multiple commits please combine them into one commit by squashing them.


