### PR TITLE
fix: Change permission from CAMERA to WRITE EXTERNAL STORAGE

### DIFF
--- a/app/src/main/java/org/apache/fineract/ui/online/customers/customerprofile/CustomerProfileActivity.java
+++ b/app/src/main/java/org/apache/fineract/ui/online/customers/customerprofile/CustomerProfileActivity.java
@@ -85,7 +85,7 @@ public class CustomerProfileActivity extends FineractBaseActivity
                         getString(R.string.customer_image));
                 return true;
             case R.id.menu_customer_profile_share:
-                checkCameraPermission();
+                checkWriteExternalStoragePermission();
                 return true;
             default:
                 return super.onOptionsItemSelected(item);
@@ -124,7 +124,7 @@ public class CustomerProfileActivity extends FineractBaseActivity
     }
 
     @Override
-    public void checkCameraPermission() {
+    public void checkWriteExternalStoragePermission() {
         if (CheckSelfPermissionAndRequest.checkSelfPermission(this,
                 Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
             shareImage();
@@ -156,7 +156,7 @@ public class CustomerProfileActivity extends FineractBaseActivity
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
                                            @NonNull int[] grantResults) {
         switch (requestCode) {
-            case ConstantKeys.PERMISSIONS_REQUEST_CAMERA: {
+            case ConstantKeys.PERMISSION_REQUEST_WRITE_EXTERNAL_STORAGE: {
                 if (grantResults.length > 0
                         && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
                     shareImage();

--- a/app/src/main/java/org/apache/fineract/ui/online/customers/customerprofile/CustomerProfileContract.java
+++ b/app/src/main/java/org/apache/fineract/ui/online/customers/customerprofile/CustomerProfileContract.java
@@ -10,7 +10,7 @@ public interface CustomerProfileContract {
 
     interface View extends MvpView {
 
-        void checkCameraPermission();
+        void checkWriteExternalStoragePermission();
 
         void requestPermission();
 


### PR DESCRIPTION
Fixes #FINCN-203

**Summary**
Changed permission from CAMERA to WRITE EXTERNAL STORAGE when clicked on "share" in appbar in CustomerProfileActivity.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.


