### PR TITLE
fix: Show message when file is not selected while editing Customer image

### DIFF
--- a/app/src/main/java/org/apache/fineract/ui/online/customers/customerprofile/editcustomerprofilebottomsheet/EditCustomerProfileBottomSheet.java
+++ b/app/src/main/java/org/apache/fineract/ui/online/customers/customerprofile/editcustomerprofilebottomsheet/EditCustomerProfileBottomSheet.java
@@ -286,7 +286,11 @@ public class EditCustomerProfileBottomSheet extends FineractBaseBottomSheetDialo
     @OnClick(R.id.btn_upload_photo)
     void uploadPhoto() {
         if (editAction == EditAction.CAMERA || editAction == EditAction.GALLERY) {
-            editCustomerProfilePresenter.uploadCustomerPortrait(customerIdentifier, file);
+            if (file != null) {
+                editCustomerProfilePresenter.uploadCustomerPortrait(customerIdentifier, file);
+            } else {
+                Toaster.show(rootView, getString(R.string.no_file_selected_yet));
+            }
         } else if (editAction == EditAction.DELETE) {
             editCustomerProfilePresenter.deleteCustomerPortrait(customerIdentifier);
         }


### PR DESCRIPTION
Fixes #FINCN-204

**Summary**
Show a snackbar while editing the customer image if the user clicks on "Upload" without selecting any file from "camera" or "gallery"

![FINCN204-gif](https://user-images.githubusercontent.com/31249460/75963010-c5ac8f00-5eea-11ea-8504-7b94a8304254.gif)


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.


