### PR TITLE
FIX-FIN203

### DIFF
--- a/app/src/main/java/org/apache/fineract/ui/online/customers/customerprofile/CustomerProfileActivity.java
+++ b/app/src/main/java/org/apache/fineract/ui/online/customers/customerprofile/CustomerProfileActivity.java
@@ -125,13 +125,13 @@ public class CustomerProfileActivity extends FineractBaseActivity
 
     @Override
     public void checkCameraPermission() {
-        if (CheckSelfPermissionAndRequest.checkSelfPermission(this,
-                Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
-            shareImage();
-        } else {
-            requestPermission();
+            if (CheckSelfPermissionAndRequest.checkSelfPermission(this,
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+                shareImage();
+            } else {
+                requestPermission();
+            }
         }
-    }
 
     @Override
     public void requestPermission() {
@@ -156,18 +156,19 @@ public class CustomerProfileActivity extends FineractBaseActivity
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
                                            @NonNull int[] grantResults) {
         switch (requestCode) {
-            case ConstantKeys.PERMISSIONS_REQUEST_CAMERA: {
-                if (grantResults.length > 0
-                        && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                    shareImage();
-                } else {
-                    Toaster.show(findViewById(android.R.id.content),
-                            getString(R.string.permission_denied_write));
-                }
+            case ConstantKeys.PERMISSIONS_REQUEST_CAMERA: {switch (requestCode) {
+                case ConstantKeys.PERMISSION_REQUEST_WRITE_EXTERNAL_STORAGE: {
+                    if (grantResults.length > 0
+                            && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                        shareImage();
+                    } else {
+                        Toaster.show(findViewById(android.R.id.content),
+                                getString(R.string.permission_denied_write));
+                    }
+                }}
             }
         }
     }
-
     @Override
     public void refreshUI() {
         loadCustomerPortrait();


### PR DESCRIPTION
Fixes #78 FIN-203

Checking for Camera Permission instead of Write Permission in CustomerProfileActivity

Click on "Customer" inside the drawer.
Click on any item in the list of customers.
Click on the profile picture (by default it's the Mifos Logo)
Click on the "Share" option in the app bar.
Supposing the permission to write to external storage is not given, it'll ask for permission. When granted it should ideally call the "share image" method, but nothing happens. This is because when the Permission is being granted, it's checking for "CAMERA" permission instead of "WRITE_EXTERNAL_STORAGE" permission.
It occurs when the permission is being granted initially and later, this error does not occur.
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [ ] Run the unit tests with `./gradlew check` to make sure you didn't break anything.

- [ ] If you have multiple commits please combine them into one commit by squashing them.


