### PR TITLE
Update CustomerProfileActivity.java

### DIFF
--- a/app/src/main/java/org/apache/fineract/ui/online/customers/customerprofile/CustomerProfileActivity.java
+++ b/app/src/main/java/org/apache/fineract/ui/online/customers/customerprofile/CustomerProfileActivity.java
@@ -168,7 +168,7 @@ public class CustomerProfileActivity extends FineractBaseActivity
                     Toaster.show(findViewById(android.R.id.content),
                             getString(R.string.permission_denied_write));
                 }
-            case ConstantKeys.PERMISSIONS_REQUEST_CAMERA: {switch (requestCode) {
+           
                 case ConstantKeys.PERMISSION_REQUEST_WRITE_EXTERNAL_STORAGE: {
                     if (grantResults.length > 0
                             && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
@@ -178,8 +178,7 @@ public class CustomerProfileActivity extends FineractBaseActivity
                                 getString(R.string.permission_denied_write));
                     }
                 }}
-            }
-        }
+            
     }
 
     @Override

--- a/app/src/main/java/org/apache/fineract/ui/online/customers/customerprofile/CustomerProfileActivity.java
+++ b/app/src/main/java/org/apache/fineract/ui/online/customers/customerprofile/CustomerProfileActivity.java
@@ -123,13 +123,19 @@ public class CustomerProfileActivity extends FineractBaseActivity
         return Uri.parse(path);
     }
 
-    @Override
+  @Override
     public void checkCameraPermission() {
         if (CheckSelfPermissionAndRequest.checkSelfPermission(this,
                 Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
             shareImage();
         } else {
             requestPermission();
+            if (CheckSelfPermissionAndRequest.checkSelfPermission(this,
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+                shareImage();
+            } else {
+                requestPermission();
+            }
         }
     }
 
@@ -144,14 +150,12 @@ public class CustomerProfileActivity extends FineractBaseActivity
                         R.string.dialog_message_write_permission_for_share_never_ask_again),
                 ConstantKeys.PERMISSIONS_WRITE_EXTERNAL_STORAGE_STATUS);
     }
-
     @Override
     public void loadCustomerPortrait() {
         ImageLoaderUtils imageLoaderUtils = new ImageLoaderUtils(this);
         imageLoaderUtils.loadImage(imageLoaderUtils.buildCustomerPortraitImageUrl(
                 customerIdentifier), ivCustomerProfile, R.drawable.mifos_logo_new);
     }
-
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
                                            @NonNull int[] grantResults) {
@@ -164,6 +168,16 @@ public class CustomerProfileActivity extends FineractBaseActivity
                     Toaster.show(findViewById(android.R.id.content),
                             getString(R.string.permission_denied_write));
                 }
+            case ConstantKeys.PERMISSIONS_REQUEST_CAMERA: {switch (requestCode) {
+                case ConstantKeys.PERMISSION_REQUEST_WRITE_EXTERNAL_STORAGE: {
+                    if (grantResults.length > 0
+                            && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                        shareImage();
+                    } else {
+                        Toaster.show(findViewById(android.R.id.content),
+                                getString(R.string.permission_denied_write));
+                    }
+                }}
             }
         }
     }
@@ -173,12 +187,10 @@ public class CustomerProfileActivity extends FineractBaseActivity
         loadCustomerPortrait();
         sweetUIErrorHandler.hideSweetErrorLayoutUI(ivCustomerProfile, errorView);
     }
-
     @Override
     public void showNoInternetConnection() {
         sweetUIErrorHandler.showSweetNoInternetUI(ivCustomerProfile, errorView);
     }
-
     @Override
     public void showError(String message) {
         sweetUIErrorHandler.showSweetCustomErrorUI(message,


### PR DESCRIPTION
Fixes #78 FIN-203

Checking for Camera Permission instead of Write Permission in CustomerProfileActivity

Click on "Customer" inside the drawer.
Click on any item in the list of customers.
Click on the profile picture (by default it's the Mifos Logo)
Click on the "Share" option in the app bar.
Supposing the permission to write to external storage is not given, it'll ask for permission. When granted it should ideally call the "share image" method, but nothing happens. This is because when the Permission is being granted, it's checking for "CAMERA" permission instead of "WRITE_EXTERNAL_STORAGE" permission.
It occurs when the permission is being granted initially and later, this error does not occur.
Please make sure these boxes are checked before submitting your pull request - thanks!

 Apply the AndroidStyle.xml style template to your code in Android Studio.

 Run the unit tests with ./gradlew check to make sure you didn't break anything.

 If you have multiple commits please combine them into one commit by squashing them.