### PR TITLE
Feat: Navigate to different fragments from dashboard screen.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,6 +17,7 @@ android {
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
+        multiDexEnabled true
     }
 
     buildTypes {
@@ -85,6 +86,8 @@ dependencies {
     implementation "androidx.cardview:cardview:$supportLibraryVersion"
     implementation "androidx.test.espresso:espresso-idling-resource:$espressoVersion"
     implementation "androidx.annotation:annotation:$supportLibraryVersion"
+    implementation "androidx.constraintlayout:constraintlayout:$constraintLayoutVersion"
+    implementation "androidx.multidex:multidex:$multidexVersion"
 
     // Kotlin Dependencies
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"

--- a/app/src/main/java/org/apache/fineract/ui/online/dashboard/DashboardFragment.java
+++ b/app/src/main/java/org/apache/fineract/ui/online/dashboard/DashboardFragment.java
@@ -2,18 +2,26 @@ package org.apache.fineract.ui.online.dashboard;
 
 import android.content.Intent;
 import android.os.Bundle;
+
 import androidx.annotation.Nullable;
+
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
 import org.apache.fineract.R;
 import org.apache.fineract.ui.base.FineractBaseFragment;
+import org.apache.fineract.ui.offline.CustomerPayloadFragment;
 import org.apache.fineract.ui.online.DashboardActivity;
+import org.apache.fineract.ui.online.accounting.accounts.AccountsFragment;
+import org.apache.fineract.ui.online.accounting.ledgers.LedgerFragment;
 import org.apache.fineract.ui.online.customers.createcustomer.CustomerAction;
 import org.apache.fineract.ui.online.customers.createcustomer.customeractivity
         .CreateCustomerActivity;
 import org.apache.fineract.ui.online.customers.customerlist.CustomersFragment;
+import org.apache.fineract.ui.online.roles.roleslist.RolesFragment;
+import org.apache.fineract.ui.online.teller.TellerFragment;
+import org.apache.fineract.ui.product.ProductFragment;
 import org.apache.fineract.utils.ConstantKeys;
 
 import butterknife.ButterKnife;
@@ -21,7 +29,7 @@ import butterknife.OnClick;
 
 /**
  * @author Rajan Maurya
- *         On 27/07/17.
+ * On 27/07/17.
  */
 public class DashboardFragment extends FineractBaseFragment {
 
@@ -37,7 +45,7 @@ public class DashboardFragment extends FineractBaseFragment {
     @Nullable
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container,
-            @Nullable Bundle savedInstanceState) {
+                             @Nullable Bundle savedInstanceState) {
         rootView = inflater.inflate(R.layout.fragment_dashboard, container, false);
         ButterKnife.bind(this, rootView);
         setToolbarTitle(getString(R.string.dashboard));
@@ -59,4 +67,53 @@ public class DashboardFragment extends FineractBaseFragment {
         intent.putExtra(ConstantKeys.CUSTOMER_ACTION, CustomerAction.CREATE);
         startActivity(intent);
     }
+
+    @OnClick(R.id.di_tellers)
+    void navigateToTeller() {
+        ((DashboardActivity) getActivity()).replaceFragment(
+                TellerFragment.Companion.newInstance(),
+                true,
+                R.id.container);
+    }
+
+    @OnClick(R.id.di_ledger)
+    void navigateToLedger() {
+        ((DashboardActivity) getActivity()).replaceFragment(
+                LedgerFragment.Companion.newInstance(),
+                true,
+                R.id.container);
+    }
+
+    @OnClick(R.id.di_customer_payload)
+    void navigateToCustomerPayloads() {
+        ((DashboardActivity) getActivity()).replaceFragment(
+                CustomerPayloadFragment.newInstance(),
+                true,
+                R.id.container);
+    }
+
+    @OnClick(R.id.di_products)
+    void navigateToProducts() {
+        ((DashboardActivity) getActivity()).replaceFragment(
+                ProductFragment.Companion.newInstance(),
+                true,
+                R.id.container);
+    }
+
+    @OnClick(R.id.di_roles_permission)
+    void navigateToRoles() {
+        ((DashboardActivity) getActivity()).replaceFragment(
+                RolesFragment.newInstance(),
+                true,
+                R.id.container);
+    }
+
+    @OnClick(R.id.di_accounts)
+    void navigateToAccounts() {
+        ((DashboardActivity) getActivity()).replaceFragment(
+                AccountsFragment.Companion.newInstance(),
+                true,
+                R.id.container);
+    }
+
 }

--- a/app/src/main/java/org/apache/fineract/ui/views/DashboardItem.kt
+++ b/app/src/main/java/org/apache/fineract/ui/views/DashboardItem.kt
@@ -1,0 +1,32 @@
+package org.apache.fineract.ui.views
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import androidx.cardview.widget.CardView
+import kotlinx.android.synthetic.main.item_dashbord_layout.view.*
+import org.apache.fineract.R
+
+class DashboardItem @JvmOverloads constructor(
+        context: Context,
+        attributeSet: AttributeSet?
+) : CardView(context, attributeSet) {
+
+    init {
+        LayoutInflater.from(context).inflate(
+                R.layout.item_dashbord_layout,
+                this, true)
+        attributeSet?.let {
+            context.theme.obtainStyledAttributes(
+                    it,
+                    R.styleable.DashboardItem,
+                    0, 0).let { typeArray ->
+                iv_icon.setImageDrawable(typeArray.getDrawable(
+                        R.styleable.DashboardItem_itemIcon))
+                tv_title.text = typeArray.getString(R.styleable.DashboardItem_title)
+
+                typeArray.recycle()
+            }
+        }
+    }
+}

--- a/app/src/main/res/layout/fragment_dashboard.xml
+++ b/app/src/main/res/layout/fragment_dashboard.xml
@@ -1,111 +1,194 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/cl_customer_deposit_details"
-    android:layout_height="match_parent"
     android:layout_width="match_parent"
-    android:orientation="vertical" >
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <androidx.cardview.widget.CardView
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
-        android:clickable="true"
-        android:foreground="?android:attr/selectableItemBackground"
-        android:id="@+id/cv_customer_deposit_details"
-        android:layout_height="wrap_content"
+    <LinearLayout
         android:layout_width="match_parent"
-        android:visibility="visible"
-        app:cardBackgroundColor="@color/colorPrimaryDark"
-        app:cardElevation="4dp">
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <androidx.cardview.widget.CardView
+            android:id="@+id/cv_customer_deposit_details"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:foreground="?android:attr/selectableItemBackground"
+            android:visibility="visible"
+            app:cardBackgroundColor="@color/colorPrimaryDark"
+            app:cardElevation="4dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:orientation="vertical"
+                android:padding="16dp">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:gravity="center"
+                    android:orientation="horizontal"
+                    android:paddingTop="@dimen/layout_padding_24dp">
+
+                    <ImageView
+                        android:layout_width="48dp"
+                        android:layout_height="48dp"
+                        android:contentDescription="@string/customer_image"
+                        android:tint="@color/white"
+                        app:srcCompat="@drawable/ic_customer_black_24dp" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="match_parent"
+                        android:gravity="center"
+                        android:paddingStart="@dimen/layout_padding_16dp"
+                        android:paddingLeft="@dimen/layout_padding_16dp"
+                        android:paddingEnd="0dp"
+                        android:paddingRight="0dp"
+                        android:text="@string/customer"
+                        android:textColor="@color/white"
+                        android:textSize="32sp"
+                        android:textStyle="bold" />
+
+                </LinearLayout>
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:gravity="center"
+                    android:orientation="vertical"
+                    android:paddingTop="@dimen/layout_padding_8dp">
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:gravity="center"
+                        android:text="@string/create_edit_customer_for_offices"
+                        android:textColor="@color/white"
+                        android:textSize="@dimen/text_medium" />
+
+                    <View
+                        android:layout_width="wrap_content"
+                        android:layout_height="1dp"
+                        android:layout_marginLeft="@dimen/layout_padding_30dp"
+                        android:layout_marginRight="@dimen/layout_padding_30dp"
+                        android:background="@color/white" />
+
+                </LinearLayout>
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:gravity="center"
+                    android:orientation="horizontal"
+                    android:paddingTop="@dimen/layout_padding_16dp"
+                    android:weightSum="2">
+
+                    <Button
+                        android:id="@+id/btn_view_customer"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:layout_weight="1"
+                        android:text="@string/view_customer"
+                        android:textAllCaps="false" />
+
+                    <Button
+                        android:id="@+id/btn_create_customer"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:layout_weight="1"
+                        android:text="@string/create_customer"
+                        android:textAllCaps="false" />
+
+                </LinearLayout>
+
+            </LinearLayout>
+
+        </androidx.cardview.widget.CardView>
 
         <LinearLayout
-            android:layout_height="match_parent"
             android:layout_width="match_parent"
-            android:orientation="vertical"
-            android:padding="16dp">
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:orientation="vertical">
 
             <LinearLayout
-                android:gravity="center"
-                android:layout_height="match_parent"
                 android:layout_width="match_parent"
-                android:orientation="horizontal"
-                android:paddingTop="@dimen/layout_padding_24dp">
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/recycler_view_item_margin"
+                android:orientation="horizontal">
 
-                <ImageView
-                    android:layout_height="48dp"
-                    android:layout_width="48dp"
-                    android:tint="@color/white"
-                    android:contentDescription="@string/customer_image"
-                    app:srcCompat="@drawable/ic_customer_black_24dp"/>
+                <org.apache.fineract.ui.views.DashboardItem
+                    android:id="@+id/di_roles_permission"
+                    android:layout_width="0dp"
+                    android:layout_height="@dimen/dashboard_item_height"
+                    android:layout_marginEnd="@dimen/recycler_view_item_margin"
+                    android:layout_marginRight="@dimen/recycler_view_item_margin"
+                    android:layout_weight="1"
+                    app:itemIcon="@drawable/ic_lock_black_24dp"
+                    app:title="@string/roles_and_permissions" />
 
-                <TextView
-                    android:gravity="center"
-                    android:layout_height="match_parent"
-                    android:layout_width="wrap_content"
-                    android:paddingEnd="0dp"
-                    android:paddingLeft="@dimen/layout_padding_16dp"
-                    android:paddingRight="0dp"
-                    android:paddingStart="@dimen/layout_padding_16dp"
-                    android:text="@string/customer"
-                    android:textColor="@color/white"
-                    android:textSize="32sp"
-                    android:textStyle="bold"/>
 
+                <org.apache.fineract.ui.views.DashboardItem
+                    android:id="@+id/di_ledger"
+                    android:layout_width="0dp"
+                    android:layout_height="@dimen/dashboard_item_height"
+                    android:layout_marginEnd="@dimen/recycler_view_item_margin"
+                    android:layout_marginRight="@dimen/recycler_view_item_margin"
+                    android:layout_weight="1"
+                    app:itemIcon="@drawable/ic_book_black_24dp"
+                    app:title="@string/ledger" />
+
+
+                <org.apache.fineract.ui.views.DashboardItem
+                    android:id="@+id/di_customer_payload"
+                    android:layout_width="0dp"
+                    android:layout_height="@dimen/dashboard_item_height"
+                    android:layout_weight="1"
+                    app:itemIcon="@drawable/ic_business_center_black_24dp"
+                    app:title="@string/customer_payloads" />
             </LinearLayout>
 
             <LinearLayout
-                android:gravity="center"
-                android:layout_height="match_parent"
                 android:layout_width="match_parent"
-                android:orientation="vertical"
-                android:paddingTop="@dimen/layout_padding_8dp">
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/recycler_view_item_margin"
+                android:layout_marginEnd="@dimen/recycler_view_item_margin"
+                android:orientation="horizontal">
 
-                <TextView
-                    android:gravity="center"
-                    android:layout_height="match_parent"
-                    android:layout_width="match_parent"
-                    android:text="@string/create_edit_customer_for_offices"
-                    android:textColor="@color/white"
-                    android:textSize="@dimen/text_medium"/>
-
-                <View
-                    android:background="@color/white"
-                    android:layout_height="1dp"
-                    android:layout_marginLeft="@dimen/layout_padding_30dp"
-                    android:layout_marginRight="@dimen/layout_padding_30dp"
-                    android:layout_width="wrap_content"/>
-
-            </LinearLayout>
-
-            <LinearLayout
-                android:gravity="center"
-                android:layout_height="match_parent"
-                android:layout_width="match_parent"
-                android:orientation="horizontal"
-                android:paddingTop="@dimen/layout_padding_16dp"
-                android:weightSum="2">
-
-                <Button
-                    android:id="@+id/btn_view_customer"
-                    android:layout_height="match_parent"
+                <org.apache.fineract.ui.views.DashboardItem
+                    android:id="@+id/di_accounts"
+                    android:layout_width="0dp"
+                    android:layout_height="@dimen/dashboard_item_height"
+                    android:layout_marginEnd="@dimen/recycler_view_item_margin"
+                    android:layout_marginRight="@dimen/recycler_view_item_margin"
                     android:layout_weight="1"
-                    android:layout_width="match_parent"
-                    android:text="@string/view_customer"
-                    android:textAllCaps="false"/>
+                    app:itemIcon="@drawable/ic_account_balance_black_24dp"
+                    app:title="@string/accounts" />
 
-                <Button
-                    android:id="@+id/btn_create_customer"
-                    android:layout_height="match_parent"
+                <org.apache.fineract.ui.views.DashboardItem
+                    android:id="@+id/di_products"
+                    android:layout_width="0dp"
+                    android:layout_height="@dimen/dashboard_item_height"
+                    android:layout_marginEnd="@dimen/recycler_view_item_margin"
+                    android:layout_marginRight="@dimen/recycler_view_item_margin"
                     android:layout_weight="1"
-                    android:layout_width="match_parent"
-                    android:text="@string/create_customer"
-                    android:textAllCaps="false"/>
+                    app:itemIcon="@drawable/ic_products_black_24dp"
+                    app:title="@string/products" />
 
+                <org.apache.fineract.ui.views.DashboardItem
+                    android:id="@+id/di_tellers"
+                    android:layout_width="0dp"
+                    android:layout_height="@dimen/dashboard_item_height"
+                    android:layout_weight="1"
+                    app:itemIcon="@drawable/ic_supervisor_account_black_24dp"
+                    app:title="@string/teller" />
             </LinearLayout>
 
         </LinearLayout>
 
-    </androidx.cardview.widget.CardView>
-
+    </LinearLayout>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/item_dashbord_layout.xml
+++ b/app/src/main/res/layout/item_dashbord_layout.xml
@@ -1,0 +1,51 @@
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="@dimen/dashboard_item_height"
+    android:background="?attr/selectableItemBackgroundBorderless"
+    app:cardBackgroundColor="@color/colorPrimary"
+    app:cardCornerRadius="@dimen/mtrl_card_corner_radius"
+    app:cardElevation="@dimen/mtrl_card_corner_radius"
+    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toTopOf="parent">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <ImageView
+            android:id="@+id/iv_icon"
+            android:layout_width="@dimen/image_height_48dp"
+            android:layout_height="@dimen/image_height_48dp"
+            android:layout_marginTop="16dp"
+            android:tint="@color/white"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:srcCompat="@tools:sample/avatars" />
+
+        <TextView
+            android:id="@+id/tv_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginLeft="16dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginRight="16dp"
+            android:layout_marginBottom="8dp"
+            android:gravity="center_horizontal"
+            android:textColor="@color/white"
+            android:textStyle="normal"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/iv_icon"
+            app:layout_constraintVertical_bias="0.48000002"
+            tools:text="Rules" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</androidx.cardview.widget.CardView>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -17,6 +17,9 @@
     <dimen name="layout_padding_64dp">64dp</dimen>
     <dimen name="layout_padding_75dp">75dp</dimen>
 
+    <dimen name="dashboard_item_height">120dp</dimen>
+    <dimen name="recycler_view_item_margin">12dp</dimen>
+
     <dimen name="header_view_start_margin_left">16dp</dimen>
     <dimen name="header_view_end_margin_left">40dp</dimen>
     <dimen name="header_view_end_margin_right">14dp</dimen>
@@ -45,4 +48,5 @@
     <dimen name="side_bar_width">5dp</dimen>
 
     <dimen name="default_fab_button_size">56dp</dimen>
+    <dimen name="image_height_48dp">48dp</dimen>
 </resources>

--- a/app/src/main/res/values/styles_view.xml
+++ b/app/src/main/res/values/styles_view.xml
@@ -14,4 +14,9 @@
     <style name="TextViewUnderline.Grey" parent="TextViewUnderline">
         <item name="android:background">@color/light_grey</item>
     </style>
+
+    <declare-styleable name="DashboardItem">
+        <attr name="title" format="string"/>
+        <attr name="itemIcon" format="integer"/>
+    </declare-styleable>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -69,4 +69,6 @@ ext {
     circleImageviewVersion = '2.1.0'
     compressorVersion = '2.1.0'
     mifosPasscodeVersion = '1.0.0'
+    constraintLayoutVersion ='2.0.0-beta4'
+    multidexVersion ='2.0.1'
 }


### PR DESCRIPTION
Fixes #FINCN-208

Changes in this PR:

1. Add support for constraint layout
2. Add support for Multidex
3. Add navigation card views to different fragments from the dashboard screen

Navigating from the dashboard to different screens improves UX and UI, Constraint layout is one of the most important layouts in modern android which is easy to use, robust and fast. We can build very complicated UIs in less time and lesser boilerplate code. To add constraint layout there was a need to support Mutlidex too.

Please Add Screenshots If any UI changes.

![Screenshot_1583938598](https://user-images.githubusercontent.com/49963168/76433220-08ce9c80-63da-11ea-8010-16ce0a87bf9c.png)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.


