### PR TITLE
fix: Deprecated attribute changed

### DIFF
--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -83,7 +83,7 @@
                 <com.google.android.material.textfield.TextInputLayout
                     android:layout_height="wrap_content"
                     android:layout_width="match_parent"
-                    app:passwordToggleEnabled="true">
+                    app:endIconMode="password_toggle">
 
                     <EditText
                         style="@style/Base.TextAppearance.AppCompat.Medium"


### PR DESCRIPTION
No UI change has been made. Only the deprecated attribute from Material TextInputLayout has been changed.

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.


