### PR TITLE
fix: Back button in different fragments in dashboard

### DIFF
--- a/app/src/main/java/org/apache/fineract/ui/base/OnBackPressed.java
+++ b/app/src/main/java/org/apache/fineract/ui/base/OnBackPressed.java
@@ -1,0 +1,5 @@
+package org.apache.fineract.ui.base;
+
+public interface OnBackPressed {
+    boolean onBackPressed();
+}

--- a/app/src/main/java/org/apache/fineract/ui/online/DashboardActivity.java
+++ b/app/src/main/java/org/apache/fineract/ui/online/DashboardActivity.java
@@ -166,6 +166,21 @@ public class DashboardActivity extends FineractBaseActivity implements
             new Handler().postDelayed(
                     () -> isBackPressedOnce = false
                     , 2000);
+        } else if (fragment instanceof CustomersFragment) {
+            if (((CustomersFragment) fragment).onBackPressed())
+                super.onBackPressed();
+        } else if (fragment instanceof LedgerFragment) {
+            if (((LedgerFragment) fragment).onBackPressed())
+                super.onBackPressed();
+        } else if (fragment instanceof AccountsFragment) {
+            if (((AccountsFragment) fragment).onBackPressed())
+                super.onBackPressed();
+        } else if (fragment instanceof TellerFragment) {
+            if (((TellerFragment) fragment).onBackPressed())
+                super.onBackPressed();
+        } else if (fragment instanceof ProductFragment) {
+            if (((ProductFragment) fragment).onBackPressed())
+                super.onBackPressed();
         } else {
             super.onBackPressed();
         }

--- a/app/src/main/java/org/apache/fineract/ui/online/accounting/accounts/AccountsFragment.kt
+++ b/app/src/main/java/org/apache/fineract/ui/online/accounting/accounts/AccountsFragment.kt
@@ -16,11 +16,13 @@ import org.apache.fineract.data.models.accounts.Account
 import org.apache.fineract.ui.adapters.AccountsAdapter
 import org.apache.fineract.ui.base.FineractBaseActivity
 import org.apache.fineract.ui.base.FineractBaseFragment
+import org.apache.fineract.ui.base.OnBackPressed
 import java.util.*
 import javax.inject.Inject
 
 
-class AccountsFragment : FineractBaseFragment(), AccountContract.View, SwipeRefreshLayout.OnRefreshListener {
+class AccountsFragment : FineractBaseFragment(), AccountContract.View,
+        SwipeRefreshLayout.OnRefreshListener, OnBackPressed {
 
     @Inject
     lateinit var accountsPresenter: AccountsPresenter
@@ -28,7 +30,8 @@ class AccountsFragment : FineractBaseFragment(), AccountContract.View, SwipeRefr
     @Inject
     lateinit var accountsAdapter: AccountsAdapter
 
-    lateinit var accountList : List<Account>
+    lateinit var accountList: List<Account>
+    private var searchView: SearchView? = null
 
     companion object {
         fun newInstance() = AccountsFragment()
@@ -37,7 +40,7 @@ class AccountsFragment : FineractBaseFragment(), AccountContract.View, SwipeRefr
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setHasOptionsMenu(true)
-        accountList= ArrayList()
+        accountList = ArrayList()
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
@@ -87,7 +90,7 @@ class AccountsFragment : FineractBaseFragment(), AccountContract.View, SwipeRefr
     private fun setUpSearchInterface(menu: Menu?) {
 
         val searchManager = activity?.getSystemService(Context.SEARCH_SERVICE) as? SearchManager
-        val searchView = menu?.findItem(R.id.account_search)?.actionView as? SearchView
+        searchView = menu?.findItem(R.id.account_search)?.actionView as? SearchView
 
         searchView?.setSearchableInfo(searchManager?.getSearchableInfo(activity?.componentName))
 
@@ -162,6 +165,15 @@ class AccountsFragment : FineractBaseFragment(), AccountContract.View, SwipeRefr
     override fun onDestroyView() {
         super.onDestroyView()
         accountsPresenter.detachView()
+    }
+
+    override fun onBackPressed(): Boolean {
+        return if (searchView?.isIconified == true)
+            true
+        else {
+            searchView?.onActionViewCollapsed()
+            false
+        }
     }
 
 }

--- a/app/src/main/java/org/apache/fineract/ui/online/accounting/ledgers/LedgerFragment.kt
+++ b/app/src/main/java/org/apache/fineract/ui/online/accounting/ledgers/LedgerFragment.kt
@@ -17,13 +17,14 @@ import org.apache.fineract.data.models.accounts.Ledger
 import org.apache.fineract.ui.adapters.LedgerAdapter
 import org.apache.fineract.ui.base.FineractBaseActivity
 import org.apache.fineract.ui.base.FineractBaseFragment
+import org.apache.fineract.ui.base.OnBackPressed
 import org.apache.fineract.ui.online.accounting.accounts.LedgerContract
 import javax.inject.Inject
 import kotlin.collections.ArrayList
 
 
 class LedgerFragment : FineractBaseFragment(), LedgerContract.View,
-        SwipeRefreshLayout.OnRefreshListener {
+        SwipeRefreshLayout.OnRefreshListener, OnBackPressed {
 
     @Inject
     lateinit var ledgerAdapter: LedgerAdapter
@@ -32,6 +33,7 @@ class LedgerFragment : FineractBaseFragment(), LedgerContract.View,
     lateinit var ledgerPresenter: LedgerPresenter
 
     lateinit var ledgerList: List<Ledger>
+    private var searchView: SearchView? = null
 
     companion object {
         fun newInstance(): LedgerFragment = LedgerFragment()
@@ -106,7 +108,7 @@ class LedgerFragment : FineractBaseFragment(), LedgerContract.View,
     private fun setUpSearchInterface(menu: Menu?) {
 
         val searchManager = activity?.getSystemService(Context.SEARCH_SERVICE) as? SearchManager
-        val searchView = menu?.findItem(R.id.ledger_search)?.actionView as? SearchView
+        searchView = menu?.findItem(R.id.ledger_search)?.actionView as? SearchView
 
         searchView?.setSearchableInfo(searchManager?.getSearchableInfo(activity?.componentName))
 
@@ -164,5 +166,14 @@ class LedgerFragment : FineractBaseFragment(), LedgerContract.View,
     override fun onDestroyView() {
         super.onDestroyView()
         ledgerPresenter.detachView()
+    }
+
+    override fun onBackPressed(): Boolean {
+        return if (searchView?.isIconified == true)
+            true
+        else {
+            searchView?.onActionViewCollapsed()
+            false
+        }
     }
 }

--- a/app/src/main/java/org/apache/fineract/ui/online/customers/customerlist/CustomersFragment.java
+++ b/app/src/main/java/org/apache/fineract/ui/online/customers/customerlist/CustomersFragment.java
@@ -6,6 +6,7 @@ import android.app.SearchManager;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+
 import androidx.annotation.Nullable;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import androidx.transition.TransitionManager;
@@ -13,6 +14,7 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.appcompat.widget.SearchView;
+
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -31,6 +33,7 @@ import org.apache.fineract.data.models.customer.Customer;
 import org.apache.fineract.ui.adapters.CustomerAdapter;
 import org.apache.fineract.ui.base.FineractBaseActivity;
 import org.apache.fineract.ui.base.FineractBaseFragment;
+import org.apache.fineract.ui.base.OnBackPressed;
 import org.apache.fineract.ui.base.OnItemClickListener;
 import org.apache.fineract.ui.base.Toaster;
 import org.apache.fineract.ui.online.customers.createcustomer.CustomerAction;
@@ -53,7 +56,7 @@ import butterknife.OnClick;
  * On 20/06/17.
  */
 public class CustomersFragment extends FineractBaseFragment implements CustomersContract.View,
-        SwipeRefreshLayout.OnRefreshListener, OnItemClickListener {
+        SwipeRefreshLayout.OnRefreshListener, OnItemClickListener, OnBackPressed {
 
     private static final Integer CUSTOMER_STATUS = 1;
 
@@ -67,6 +70,7 @@ public class CustomersFragment extends FineractBaseFragment implements Customers
     View layoutError;
 
     View rootView;
+    SearchView searchView;
 
     @Inject
     CustomersPresenter customerPresenter;
@@ -264,7 +268,7 @@ public class CustomersFragment extends FineractBaseFragment implements Customers
 
         SearchManager manager = (SearchManager) getActivity().
                 getSystemService(Context.SEARCH_SERVICE);
-        SearchView searchView = (SearchView) menu.findItem(
+        searchView = (SearchView) menu.findItem(
                 R.id.menu_customer_search).getActionView();
         searchView.setSearchableInfo(manager.getSearchableInfo(getActivity().getComponentName()));
 
@@ -296,9 +300,7 @@ public class CustomersFragment extends FineractBaseFragment implements Customers
         searchView.setOnCloseListener(new SearchView.OnCloseListener() {
             @Override
             public boolean onClose() {
-                rgSearch.clearCheck();
-                TransitionManager.beginDelayedTransition(coordinator);
-                llSearch.setVisibility(View.GONE);
+                closeSearch();
                 return false;
             }
         });
@@ -312,6 +314,12 @@ public class CustomersFragment extends FineractBaseFragment implements Customers
         } else if (rbOnline.isChecked()) {
             customerPresenter.searchCustomerOnline(query);
         }
+    }
+
+    private void closeSearch() {
+        rgSearch.clearCheck();
+        TransitionManager.beginDelayedTransition(coordinator);
+        llSearch.setVisibility(View.GONE);
     }
 
 
@@ -337,6 +345,17 @@ public class CustomersFragment extends FineractBaseFragment implements Customers
                     ConstantKeys.CUSTOMER_STATUS);
             customers.get(detailsCustomerPosition).setCurrentState(state);
             customerAdapter.notifyItemChanged(detailsCustomerPosition);
+        }
+    }
+
+    @Override
+    public boolean onBackPressed() {
+        if (searchView.isIconified()) {
+            return true;
+        } else {
+            searchView.onActionViewCollapsed();
+            closeSearch();
+            return false;
         }
     }
 }

--- a/app/src/main/java/org/apache/fineract/ui/online/teller/TellerFragment.kt
+++ b/app/src/main/java/org/apache/fineract/ui/online/teller/TellerFragment.kt
@@ -16,11 +16,13 @@ import org.apache.fineract.data.models.teller.Teller
 import org.apache.fineract.ui.adapters.TellerAdapter
 import org.apache.fineract.ui.base.FineractBaseActivity
 import org.apache.fineract.ui.base.FineractBaseFragment
+import org.apache.fineract.ui.base.OnBackPressed
 import java.util.*
 import javax.inject.Inject
 
 
-class TellerFragment : FineractBaseFragment(), TellerContract.View, SwipeRefreshLayout.OnRefreshListener {
+class TellerFragment : FineractBaseFragment(), TellerContract.View,
+        SwipeRefreshLayout.OnRefreshListener, OnBackPressed {
 
     @Inject
     lateinit var tellPresenter: TellerPresenter
@@ -29,6 +31,7 @@ class TellerFragment : FineractBaseFragment(), TellerContract.View, SwipeRefresh
     lateinit var tellerAdapter: TellerAdapter
 
     lateinit var tellerList: List<Teller>
+    private var searchView: SearchView? = null
 
     companion object {
         fun newInstance(): TellerFragment = TellerFragment().apply {
@@ -106,7 +109,7 @@ class TellerFragment : FineractBaseFragment(), TellerContract.View, SwipeRefresh
     private fun setUpSearchInterface(menu: Menu?) {
 
         val searchManager = activity?.getSystemService(Context.SEARCH_SERVICE) as? SearchManager
-        val searchView = menu?.findItem(R.id.teller_search)?.actionView as? SearchView
+        searchView = menu?.findItem(R.id.teller_search)?.actionView as? SearchView
 
         searchView?.setSearchableInfo(searchManager?.getSearchableInfo(activity?.componentName))
 
@@ -164,5 +167,14 @@ class TellerFragment : FineractBaseFragment(), TellerContract.View, SwipeRefresh
     override fun onDestroyView() {
         super.onDestroyView()
         tellPresenter.detachView()
+    }
+
+    override fun onBackPressed(): Boolean {
+        return if (searchView?.isIconified == true)
+            true
+        else {
+            searchView?.onActionViewCollapsed()
+            false
+        }
     }
 }

--- a/app/src/main/java/org/apache/fineract/ui/product/ProductFragment.kt
+++ b/app/src/main/java/org/apache/fineract/ui/product/ProductFragment.kt
@@ -16,12 +16,13 @@ import org.apache.fineract.data.models.product.Product
 import org.apache.fineract.ui.adapters.ProductAdapter
 import org.apache.fineract.ui.base.FineractBaseActivity
 import org.apache.fineract.ui.base.FineractBaseFragment
+import org.apache.fineract.ui.base.OnBackPressed
 import java.util.*
 import javax.inject.Inject
 
 
 class ProductFragment : FineractBaseFragment(), ProductContract.View,
-        SwipeRefreshLayout.OnRefreshListener {
+        SwipeRefreshLayout.OnRefreshListener, OnBackPressed {
 
     @Inject
     lateinit var productPresenter: ProductPresenter
@@ -30,6 +31,7 @@ class ProductFragment : FineractBaseFragment(), ProductContract.View,
     lateinit var productAdapter: ProductAdapter
 
     lateinit var productList: List<Product>
+    private var searchView: SearchView? = null
 
     companion object {
         fun newInstance() = ProductFragment().apply {
@@ -102,7 +104,7 @@ class ProductFragment : FineractBaseFragment(), ProductContract.View,
     private fun setUpSearchInterface(menu: Menu?) {
 
         val searchManager = activity?.getSystemService(Context.SEARCH_SERVICE) as? SearchManager
-        val searchView = menu?.findItem(R.id.product_search)?.actionView as? SearchView
+        searchView = menu?.findItem(R.id.product_search)?.actionView as? SearchView
 
         searchView?.setSearchableInfo(searchManager?.getSearchableInfo(activity?.componentName))
 
@@ -169,6 +171,15 @@ class ProductFragment : FineractBaseFragment(), ProductContract.View,
     override fun onDestroyView() {
         super.onDestroyView()
         productPresenter.detachView()
+    }
+
+    override fun onBackPressed(): Boolean {
+        return if (searchView?.isIconified == true)
+            true
+        else {
+            searchView?.onActionViewCollapsed()
+            false
+        }
     }
 
 }


### PR DESCRIPTION
Fixes #FINCN-211
https://issues.apache.org/jira/browse/FINCN-211

![ezgif com-video-to-gif (3)](https://user-images.githubusercontent.com/42939575/76780807-a3ace980-67d3-11ea-8a70-58575e95de50.gif)

Earlier if you pressed back while in Customer fragment with something on the search bar, you would be thrown back to Dashboard fragment. This change makes the app smooth and more practical by first dismissing the search bar and then going back to Dashboard  fragment after that.


- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.


