### PR TITLE
fixes: Switching EditText Field from Keyboard

### DIFF
--- a/app/src/main/res/layout/fragment_form_customer_address.xml
+++ b/app/src/main/res/layout/fragment_form_customer_address.xml
@@ -64,7 +64,8 @@
                             android:inputType="text"
                             android:layout_height="wrap_content"
                             android:layout_width="match_parent"
-                            android:digits="@string/restrict_a_zA_Z"/>
+                            android:digits="@string/restrict_a_zA_Z"
+                            android:singleLine="true"/>
                     </com.google.android.material.textfield.TextInputLayout>
 
                     <com.google.android.material.textfield.TextInputLayout
@@ -93,7 +94,8 @@
                             android:inputType="text"
                             android:layout_height="wrap_content"
                             android:layout_width="match_parent"
-                            android:digits="@string/restrict_a_zA_Z"/>
+                            android:digits="@string/restrict_a_zA_Z"
+                            android:singleLine="true"/>
                     </com.google.android.material.textfield.TextInputLayout>
 
                     <com.google.android.material.textfield.TextInputLayout
@@ -108,7 +110,8 @@
                             android:inputType="text"
                             android:layout_height="wrap_content"
                             android:layout_width="match_parent"
-                            android:digits="@string/restrict_a_zA_Z"/>
+                            android:digits="@string/restrict_a_zA_Z"
+                            android:singleLine="true"/>
                     </com.google.android.material.textfield.TextInputLayout>
 
                 </LinearLayout>

--- a/app/src/main/res/layout/fragment_form_customer_details.xml
+++ b/app/src/main/res/layout/fragment_form_customer_details.xml
@@ -50,7 +50,8 @@
                             android:inputType="text"
                             android:digits="@string/restrict_a_zA_Z0_9"
                             android:layout_height="wrap_content"
-                            android:layout_width="match_parent"/>
+                            android:layout_width="match_parent"
+                            android:singleLine="true"/>
                     </com.google.android.material.textfield.TextInputLayout>
 
                     <com.google.android.material.textfield.TextInputLayout
@@ -65,7 +66,8 @@
                             android:inputType="text"
                             android:digits="@string/restrict_a_zA_Z"
                             android:layout_height="wrap_content"
-                            android:layout_width="match_parent"/>
+                            android:layout_width="match_parent"
+                            android:singleLine="true"/>
                     </com.google.android.material.textfield.TextInputLayout>
 
                     <com.google.android.material.textfield.TextInputLayout
@@ -80,7 +82,8 @@
                             android:inputType="text"
                             android:digits="@string/restrict_a_zA_Z"
                             android:layout_height="wrap_content"
-                            android:layout_width="match_parent"/>
+                            android:layout_width="match_parent"
+                            android:singleLine="true"/>
                     </com.google.android.material.textfield.TextInputLayout>
 
                     <com.google.android.material.textfield.TextInputLayout
@@ -95,7 +98,8 @@
                             android:inputType="text"
                             android:digits="@string/restrict_a_zA_Z"
                             android:layout_height="wrap_content"
-                            android:layout_width="match_parent"/>
+                            android:layout_width="match_parent"
+                            android:singleLine="true"/>
                     </com.google.android.material.textfield.TextInputLayout>
 
                     <com.google.android.material.textfield.TextInputLayout


### PR DESCRIPTION
Fixes #FINCN-212
https://issues.apache.org/jira/browse/FINCN-212

![ezgif com-video-to-gif (6)](https://user-images.githubusercontent.com/42939575/76888154-7468ac00-68a9-11ea-9037-a173cf20b828.gif)

Now, one can switch the edit Text Fields from keyboard itself, without automatically clicking on the next EditText in forms.

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.


