### PR TITLE
fix: Differ fake data from actual network response in LoanAccounts

### DIFF
--- a/app/src/main/java/org/apache/fineract/data/models/loan/LoanAccount.kt
+++ b/app/src/main/java/org/apache/fineract/data/models/loan/LoanAccount.kt
@@ -19,7 +19,8 @@ data class LoanAccount(
     @SerializedName("createdOn") var createdOn: String? = null,
     @SerializedName("createdBy") var createdBy: String? = null,
     @SerializedName("lastModifiedOn") var lastModifiedOn: String? = null,
-    @SerializedName("lastModifiedBy") var lastModifiedBy: String? = null
+    @SerializedName("lastModifiedBy") var lastModifiedBy: String? = null,
+    @SerializedName("isFakeData") var isFakeData: Boolean? = false
 ) {
 
     private val loanParameters: LoanParameters? = null

--- a/app/src/main/java/org/apache/fineract/ui/online/loanaccounts/loanaccountlist/LoanAccountsFragment.java
+++ b/app/src/main/java/org/apache/fineract/ui/online/loanaccounts/loanaccountlist/LoanAccountsFragment.java
@@ -137,7 +137,10 @@ public class LoanAccountsFragment extends FineractBaseFragment implements LoanAc
         rvCustomerLoans.addOnScrollListener(new EndlessRecyclerViewScrollListener(layoutManager) {
             @Override
             public void onLoadMore(int page, int totalItemsCount) {
-                customerLoansPresenter.fetchCustomerLoanAccounts(customerIdentifier, page, true);
+                if (!loanAccounts.get(0).isFakeData()) {
+                    customerLoansPresenter.fetchCustomerLoanAccounts(
+                            customerIdentifier, page, true);
+                }
             }
         });
     }

--- a/app/src/main/resources/loanAccountPage.json
+++ b/app/src/main/resources/loanAccountPage.json
@@ -53,7 +53,8 @@
           "alignmentWeek": 1,
           "alignmentMonth": 1
         }
-      }
+      },
+      "isFakeData": true
     }
   ],
   "totalElements": 1


### PR DESCRIPTION
Fixes #FINCN-206

**Summary**
Unlimited entries  being created while swiping down the list of loan accounts for a customer. This is beacuse the actual response data and the fake data was treated the same.

**Observed Behaviour**
![206problemgif](https://user-images.githubusercontent.com/31249460/77106858-c9412980-6a45-11ea-980f-bbefaa6191a0.gif)


**Expected Behaviour**
![206solngif](https://user-images.githubusercontent.com/31249460/77106144-a82c0900-6a44-11ea-9d15-e05294732c9a.gif)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.


