### PR TITLE
fix: Header of stepper made interactive while creating customer

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,7 +19,8 @@
         android:icon="@drawable/launcher_image"
         android:label="@string/app_name"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        android:usesCleartextTraffic="true">
 
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,8 +19,7 @@
         android:icon="@drawable/launcher_image"
         android:label="@string/app_name"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme"
-        android:usesCleartextTraffic="true">
+        android:theme="@style/AppTheme">
 
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/app/src/main/java/org/apache/fineract/ui/online/customers/createcustomer/customeractivity/CreateCustomerActivity.java
+++ b/app/src/main/java/org/apache/fineract/ui/online/customers/createcustomer/customeractivity/CreateCustomerActivity.java
@@ -124,6 +124,7 @@ public class CreateCustomerActivity extends FineractBaseActivity
 
     @Override
     public void onStepSelected(int newStepPosition) {
+        hideKeyboard(stepperLayout.getRootView());
     }
 
     @Override

--- a/app/src/main/res/layout/activity_create_customer.xml
+++ b/app/src/main/res/layout/activity_create_customer.xml
@@ -24,7 +24,7 @@
             app:ms_inactiveStepColor="#cccccc"
             app:ms_nextButtonColor="#FFFFFF"
             app:ms_stepperType="tabs"
-            app:ms_tabNavigationEnabled="false"
+            app:ms_tabNavigationEnabled="true"
             app:ms_tabStepDividerWidth="138dp"
             app:ms_stepperFeedbackType="tabs|content|disabled_bottom_navigation"/>
 


### PR DESCRIPTION
Fixes #FINCN-43

**Summary**
While creating Customer, the header of the stepper is made interactive.

**Expected Behaviour**
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/31249460/77186319-b3407100-6af8-11ea-8c9d-ced3d3950964.gif)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.


