### PR TITLE
fix: Warning on going back in forms

### DIFF
--- a/app/src/main/java/org/apache/fineract/ui/online/customers/createcustomer/customeractivity/CreateCustomerActivity.java
+++ b/app/src/main/java/org/apache/fineract/ui/online/customers/createcustomer/customeractivity/CreateCustomerActivity.java
@@ -20,6 +20,7 @@ import org.apache.fineract.ui.online.customers.createcustomer.CustomerAction;
 import org.apache.fineract.ui.online.customers.createcustomer.OnNavigationBarListener;
 import org.apache.fineract.ui.online.customers.customerdetails.CustomerDetailsActivity;
 import org.apache.fineract.utils.ConstantKeys;
+import org.apache.fineract.utils.MaterialDialog;
 
 import java.util.List;
 
@@ -202,6 +203,20 @@ public class CreateCustomerActivity extends FineractBaseActivity
     public void showError(String message) {
         stepperLayout.setNextButtonEnabled(true);
         Toaster.show(findViewById(android.R.id.content), message);
+    }
+
+    @Override
+    public void onBackPressed() {
+        new MaterialDialog.Builder()
+                .init(this)
+                .setTitle(getString(R.string.dialog_title_confirm_back))
+                .setMessage(getString(R.string.dialog_message_confirmation_back))
+                .setPositiveButton(getString(R.string.dialog_action_go_back),
+                        (dialog, which) -> super.onBackPressed()
+                )
+                .setNegativeButton(getString(R.string.dialog_action_stay))
+                .createMaterialDialog()
+                .show();
     }
 
     @Override

--- a/app/src/main/java/org/apache/fineract/ui/online/customers/customerpayroll/editcustomerpayroll/EditPayrollActivity.kt
+++ b/app/src/main/java/org/apache/fineract/ui/online/customers/customerpayroll/editcustomerpayroll/EditPayrollActivity.kt
@@ -1,5 +1,6 @@
 package org.apache.fineract.ui.online.customers.customerpayroll.editcustomerpayroll
 
+import android.content.DialogInterface
 import android.os.Bundle
 import android.view.View
 import com.stepstone.stepper.StepperLayout
@@ -13,6 +14,7 @@ import org.apache.fineract.ui.base.FineractBaseActivity
 import org.apache.fineract.ui.base.Toaster
 import org.apache.fineract.ui.online.accounting.accounts.EditPayrollContract
 import org.apache.fineract.utils.ConstantKeys
+import org.apache.fineract.utils.MaterialDialog
 import javax.inject.Inject
 
 class EditPayrollActivity : FineractBaseActivity(), StepperLayout.StepperListener,
@@ -83,6 +85,18 @@ class EditPayrollActivity : FineractBaseActivity(), StepperLayout.StepperListene
 
     override fun showError(message: String?) {
         Toaster.show(findViewById(android.R.id.content), message)
+    }
+
+    override fun onBackPressed() {
+        MaterialDialog.Builder()
+                .init(this)
+                .setTitle(getString(R.string.dialog_title_confirm_back))
+                .setMessage(getString(R.string.dialog_message_confirmation_back))
+                .setPositiveButton(getString(R.string.dialog_action_go_back)
+                ) { _: DialogInterface?, _: Int -> super.onBackPressed() }
+                .setNegativeButton(getString(R.string.dialog_action_stay))
+                .createMaterialDialog()
+                .show()
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/org/apache/fineract/ui/online/depositaccounts/createdepositaccount/createdepositactivity/CreateDepositActivity.java
+++ b/app/src/main/java/org/apache/fineract/ui/online/depositaccounts/createdepositaccount/createdepositactivity/CreateDepositActivity.java
@@ -16,6 +16,7 @@ import org.apache.fineract.ui.online.depositaccounts.createdepositaccount
         .DepositOnNavigationBarListener;
 import org.apache.fineract.ui.online.depositaccounts.createdepositaccount.DepositOverViewContract;
 import org.apache.fineract.utils.ConstantKeys;
+import org.apache.fineract.utils.MaterialDialog;
 
 import javax.inject.Inject;
 
@@ -172,5 +173,19 @@ public class CreateDepositActivity extends FineractBaseActivity implements
         stepperLayout.setNextButtonEnabled(true);
         stepperLayout.setBackButtonEnabled(true);
         Toaster.show(findViewById(android.R.id.content), message);
+    }
+
+    @Override
+    public void onBackPressed() {
+        new MaterialDialog.Builder()
+                .init(this)
+                .setTitle(getString(R.string.dialog_title_confirm_back))
+                .setMessage(getString(R.string.dialog_message_confirmation_back))
+                .setPositiveButton(getString(R.string.dialog_action_go_back),
+                        (dialog, which) -> super.onBackPressed()
+                )
+                .setNegativeButton(getString(R.string.dialog_action_stay))
+                .createMaterialDialog()
+                .show();
     }
 }

--- a/app/src/main/java/org/apache/fineract/ui/online/identification/createidentification/identificationactivity/CreateIdentificationActivity.java
+++ b/app/src/main/java/org/apache/fineract/ui/online/identification/createidentification/identificationactivity/CreateIdentificationActivity.java
@@ -18,6 +18,7 @@ import org.apache.fineract.ui.online.identification.createidentification.Action;
 import org.apache.fineract.ui.online.identification.createidentification.OnNavigationBarListener;
 import org.apache.fineract.ui.online.identification.createidentification.OverViewContract;
 import org.apache.fineract.utils.ConstantKeys;
+import org.apache.fineract.utils.MaterialDialog;
 
 import javax.inject.Inject;
 
@@ -179,6 +180,20 @@ public class CreateIdentificationActivity extends FineractBaseActivity
         stepperLayout.setNextButtonEnabled(true);
         stepperLayout.setBackButtonEnabled(true);
         Toaster.show(findViewById(android.R.id.content), message);
+    }
+
+    @Override
+    public void onBackPressed() {
+        new MaterialDialog.Builder()
+                .init(this)
+                .setTitle(getString(R.string.dialog_title_confirm_back))
+                .setMessage(getString(R.string.dialog_message_confirmation_back))
+                .setPositiveButton(getString(R.string.dialog_action_go_back),
+                        (dialog, which) -> super.onBackPressed()
+                )
+                .setNegativeButton(getString(R.string.dialog_action_stay))
+                .createMaterialDialog()
+                .show();
     }
 
     @Override

--- a/app/src/main/java/org/apache/fineract/ui/online/loanaccounts/loanapplication/loanactivity/LoanApplicationActivity.java
+++ b/app/src/main/java/org/apache/fineract/ui/online/loanaccounts/loanapplication/loanactivity/LoanApplicationActivity.java
@@ -19,6 +19,7 @@ import org.apache.fineract.ui.base.FineractBaseActivity;
 import org.apache.fineract.ui.base.Toaster;
 import org.apache.fineract.ui.online.loanaccounts.loanapplication.OnNavigationBarListener;
 import org.apache.fineract.utils.ConstantKeys;
+import org.apache.fineract.utils.MaterialDialog;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -183,6 +184,20 @@ public class LoanApplicationActivity extends FineractBaseActivity
     @Override
     public List<CreditWorthinessSnapshot> getCreditWorthinessSnapshot() {
         return creditWorthinessSnapshots;
+    }
+
+    @Override
+    public void onBackPressed() {
+        new MaterialDialog.Builder()
+                .init(this)
+                .setTitle(getString(R.string.dialog_title_confirm_back))
+                .setMessage(getString(R.string.dialog_message_confirmation_back))
+                .setPositiveButton(getString(R.string.dialog_action_go_back),
+                        (dialog, which) -> super.onBackPressed()
+                )
+                .setNegativeButton(getString(R.string.dialog_action_stay))
+                .createMaterialDialog()
+                .show();
     }
 
     @Override

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -311,6 +311,10 @@
     <string name="dialog_action_logout">Logout</string>
     <string name="dialog_title_confirm_deletion">Confirm deletion</string>
     <string name="dialog_title_confirm_logout">Confirm logout</string>
+    <string name="dialog_title_confirm_back">Are you sure you want to go back?</string>
+    <string name="dialog_message_confirmation_back">All unsaved changes will be lost.</string>
+    <string name="dialog_action_go_back">Yes</string>
+    <string name="dialog_action_stay">No</string>
     <string name="dialog_message_confirmation_delete_identification_card">Do you want to delete this identification card?</string>
     <string name="dialog_message_confirmation_delete_identification_card_scan">Do you want to delete this identification card scan?</string>
     <string name="dialog_message_confirmation_logout">Are you sure? you want to logout</string>


### PR DESCRIPTION
Fixes #FINCN-213
https://issues.apache.org/jira/browse/FINCN-213

![ezgif com-video-to-gif (8)](https://user-images.githubusercontent.com/42939575/77227358-d543fd00-6ba5-11ea-86bc-389414bdfee0.gif)

Please Add Screenshots If any UI changes.

Earlier the forms would go back on pressing just one back button in create customer activity. This now gives a warning to the user that they would lose their existing changes made in to the form.


- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.


