### PR TITLE
fix: Remove Logout title on toolbar during logout

### DIFF
--- a/app/src/main/java/org/apache/fineract/ui/online/DashboardActivity.java
+++ b/app/src/main/java/org/apache/fineract/ui/online/DashboardActivity.java
@@ -142,7 +142,9 @@ public class DashboardActivity extends FineractBaseActivity implements
         }
 
         drawerLayout.closeDrawer(GravityCompat.START);
-        setTitle(item.getTitle());
+        if (item.getItemId() != R.id.item_logout) {
+            setTitle(item.getTitle());
+        }
         return true;
     }
 


### PR DESCRIPTION
Fixes #FINCN-217 [here](https://issues.apache.org/jira/browse/FINCN-217?jql=project%20%3D%20FINCN)

**Summary**
Remove "Logout" title on toolbar after clicking on logout in side drawer. The "Logout" title remains even after choosing not to logout.

**Observed Behaviour**
![ezgif com-video-to-gif (4)](https://user-images.githubusercontent.com/31249460/77232498-68d9f580-6bc7-11ea-930d-7fb51cc1127e.gif)

**Expected Behaviour**
![ezgif com-video-to-gif (5)](https://user-images.githubusercontent.com/31249460/77232642-4e544c00-6bc8-11ea-9f6a-9fa9428f6bf1.gif)


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.


