### PR TITLE
FINCN-112: Update compile and target SDK versions of the app

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,9 +32,9 @@ task clean(type: Delete) {
 ext {
     // Sdk and tools
     minSdkVersion = 16
-    targetSdkVersion = 28
-    compileSdkVersion = 28
-    buildToolsVersion = '28.0.3'
+    targetSdkVersion = 29
+    compileSdkVersion = 29
+    buildToolsVersion = '29.0.3'
 
     // App dependencies
     supportLibraryVersion = '1.0.0'


### PR DESCRIPTION
Fixes #112

The issue said "Android SDK version 27 must be changed to 28", but the project's SDK version was already 28. After talking to @xurror, we had an agreement to changed it it to 29.

Android SDK changing was successful. There were no errors or new warnings after project building.


- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything.

- [ ] If you have multiple commits please combine them into one commit by squashing them.


