### PR TITLE
Fixes FINCN-241: kotlin-kapt error

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.application'
-apply plugin: 'kotlin-kapt'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-kapt'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'io.fabric'
 apply from: '../config/quality/quality.gradle'


### PR DESCRIPTION
The kotlin-android plugin must come before the kotlin-kapt plugin,
without which the application cannot run.

This pull request fixes the plugin order in app/build.gradle.

Fixes #FINCN-241
https://issues.apache.org/jira/browse/FINCN-241
