### PR TITLE
fix the activity_debt_income_report.xml Toolbar scrolling behavior

### DIFF
--- a/app/src/main/res/layout/activity_debt_income_report.xml
+++ b/app/src/main/res/layout/activity_debt_income_report.xml
@@ -17,7 +17,6 @@
             android:id="@+id/toolbar"
             android:layout_height="?attr/actionBarSize"
             android:layout_width="match_parent"
-            app:layout_scrollFlags="scroll|enterAlways|snap"
             app:popupTheme="@style/ThemeOverlay.AppCompat.Light"/>
 
         <com.google.android.material.tabs.TabLayout


### PR DESCRIPTION
Fixes FINCN-246

https://user-images.githubusercontent.com/56648862/110343521-93c88e00-8052-11eb-9e8d-9474ce75ec3f.mp4

Stopped the toolbar from scrolling upward.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.


