### PR TITLE
Bug: Duplicate Enteries shown in the PlannedPaymentActivity screen until Reloading

### DIFF
--- a/app/src/main/java/org/apache/fineract/ui/online/loanaccounts/plannedpayment/PlannedPaymentPresenter.java
+++ b/app/src/main/java/org/apache/fineract/ui/online/loanaccounts/plannedpayment/PlannedPaymentPresenter.java
@@ -56,7 +56,7 @@ public class PlannedPaymentPresenter extends BasePresenter<PlannedPaymentContrac
     @Override
     public void fetchPlannedPayment(String productIdentifier, String caseIdentifier,
             Integer pageIndex, String initialDisbursalDate, Boolean loadmore) {
-        this.loadmore = loadmore;
+//        this.loadmore = loadmore;
         fetchPlannedPayment(productIdentifier, caseIdentifier, pageIndex, initialDisbursalDate);
     }
 


### PR DESCRIPTION
Fixes #FINCN-247

https://user-images.githubusercontent.com/53621853/110980407-d6100900-838b-11eb-836c-8049b5876a2d.mp4

In the above video, it can be clearly seen that on going to the PlannedPaymentActivity, duplicate enteries are shown, but on reloading only one s left.

Steps to reproduce: view customer -> any customer -> loan accounts -> select any loan account -> go to planned payment screen -> two entries are shown and on reloading , only one is shown.

The issue has been solved and shown in the above Video :arrow_down: :

https://user-images.githubusercontent.com/53621853/110980732-2f783800-838c-11eb-8f67-046c34ec9cc3.mp4


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.


