### PR TITLE
Fix-253: FAB behaviour rectified in LoanAccountsFragment

### DIFF
--- a/app/src/main/java/org/apache/fineract/ui/online/loanaccounts/loanaccountlist/LoanAccountsFragment.java
+++ b/app/src/main/java/org/apache/fineract/ui/online/loanaccounts/loanaccountlist/LoanAccountsFragment.java
@@ -4,6 +4,8 @@ import android.app.SearchManager;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import androidx.recyclerview.widget.LinearLayoutManager;
@@ -15,6 +17,8 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.View;
 import android.view.ViewGroup;
+
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
 import org.apache.fineract.R;
 import org.apache.fineract.data.models.loan.LoanAccount;
@@ -52,6 +56,9 @@ public class LoanAccountsFragment extends FineractBaseFragment implements LoanAc
 
     @BindView(R.id.layout_error)
     View layoutError;
+
+    @BindView(R.id.fab_add_customer_loan)
+    FloatingActionButton fabAddCustomerLoan;
 
     @Inject
     LoanAccountsPresenter customerLoansPresenter;
@@ -138,6 +145,18 @@ public class LoanAccountsFragment extends FineractBaseFragment implements LoanAc
             @Override
             public void onLoadMore(int page, int totalItemsCount) {
                 customerLoansPresenter.fetchCustomerLoanAccounts(customerIdentifier, page, true);
+            }
+        });
+
+        rvCustomerLoans.addOnScrollListener(new RecyclerView.OnScrollListener() {
+            @Override
+            public void onScrollStateChanged(@NonNull RecyclerView recyclerView, int newState) {
+                super.onScrollStateChanged(recyclerView, newState);
+                if (newState == RecyclerView.SCROLL_STATE_IDLE) {
+                    fabAddCustomerLoan.show();
+                } else {
+                    fabAddCustomerLoan.hide();
+                }
             }
         });
     }

--- a/app/src/main/res/layout/fragment_customer_loans.xml
+++ b/app/src/main/res/layout/fragment_customer_loans.xml
@@ -33,7 +33,6 @@
         android:layout_height="wrap_content"
         android:layout_margin="@dimen/fab_margin"
         android:layout_width="wrap_content"
-        app:layout_behavior="org.apache.fineract.utils.ScrollFabBehavior"
         app:srcCompat="@drawable/ic_add_black_24dp"/>
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
Fixes [FINCN-253](https://issues.apache.org/jira/browse/FINCN-253)

Fab is now visible as soon as list gets idle from scrolling.

**Error**

https://user-images.githubusercontent.com/70195106/111025808-b79e2200-840c-11eb-936b-0ae14258e967.mp4

**Solution**

https://user-images.githubusercontent.com/70195106/111025890-267b7b00-840d-11eb-8cf4-fb39ab238d7f.mp4



- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.
