### PR TITLE
Fix-254: SearchView error fixed in all fragments

### DIFF
--- a/app/src/main/java/org/apache/fineract/ui/online/accounting/accounts/AccountsFragment.kt
+++ b/app/src/main/java/org/apache/fineract/ui/online/accounting/accounts/AccountsFragment.kt
@@ -90,6 +90,7 @@ class AccountsFragment : FineractBaseFragment(), AccountContract.View, SwipeRefr
         val searchView = menu?.findItem(R.id.account_search)?.actionView as? SearchView
 
         searchView?.setSearchableInfo(searchManager?.getSearchableInfo(activity?.componentName))
+        searchView?.maxWidth = Int.MAX_VALUE
 
         searchView?.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
             override fun onQueryTextSubmit(query: String): Boolean {

--- a/app/src/main/java/org/apache/fineract/ui/online/accounting/ledgers/LedgerFragment.kt
+++ b/app/src/main/java/org/apache/fineract/ui/online/accounting/ledgers/LedgerFragment.kt
@@ -109,6 +109,7 @@ class LedgerFragment : FineractBaseFragment(), LedgerContract.View,
         val searchView = menu?.findItem(R.id.ledger_search)?.actionView as? SearchView
 
         searchView?.setSearchableInfo(searchManager?.getSearchableInfo(activity?.componentName))
+        searchView?.maxWidth = Int.MAX_VALUE
 
         searchView?.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
             override fun onQueryTextSubmit(query: String): Boolean {

--- a/app/src/main/java/org/apache/fineract/ui/online/customers/customerlist/CustomersFragment.java
+++ b/app/src/main/java/org/apache/fineract/ui/online/customers/customerlist/CustomersFragment.java
@@ -267,6 +267,7 @@ public class CustomersFragment extends FineractBaseFragment implements Customers
         SearchView searchView = (SearchView) menu.findItem(
                 R.id.menu_customer_search).getActionView();
         searchView.setSearchableInfo(manager.getSearchableInfo(getActivity().getComponentName()));
+        searchView.setMaxWidth(Integer.MAX_VALUE);
 
         searchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
             @Override

--- a/app/src/main/java/org/apache/fineract/ui/online/groups/grouplist/GroupListFragment.kt
+++ b/app/src/main/java/org/apache/fineract/ui/online/groups/grouplist/GroupListFragment.kt
@@ -95,6 +95,7 @@ class GroupListFragment : FineractBaseFragment(), OnItemClickListener {
         val searchView = menu.findItem(R.id.group_search).actionView as SearchView
 
         searchView.setSearchableInfo(searchManager.getSearchableInfo(activity?.componentName))
+        searchView.maxWidth = Int.MAX_VALUE
 
         searchView.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
             override fun onQueryTextSubmit(query: String): Boolean {

--- a/app/src/main/java/org/apache/fineract/ui/online/identification/identificationlist/IdentificationsFragment.java
+++ b/app/src/main/java/org/apache/fineract/ui/online/identification/identificationlist/IdentificationsFragment.java
@@ -204,6 +204,7 @@ public class IdentificationsFragment extends FineractBaseFragment implements
         final SearchView searchView = (SearchView) menu.findItem(
                 R.id.identification_search).getActionView();
         searchView.setSearchableInfo(manager.getSearchableInfo(getActivity().getComponentName()));
+        searchView.setMaxWidth(Integer.MAX_VALUE);
 
         searchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
             @Override

--- a/app/src/main/java/org/apache/fineract/ui/online/loanaccounts/loanaccountlist/LoanAccountsFragment.java
+++ b/app/src/main/java/org/apache/fineract/ui/online/loanaccounts/loanaccountlist/LoanAccountsFragment.java
@@ -236,6 +236,7 @@ public class LoanAccountsFragment extends FineractBaseFragment implements LoanAc
                 .getActionView();
         searchView.setSearchableInfo(searchManager.getSearchableInfo(getActivity()
                 .getComponentName()));
+        searchView.setMaxWidth(Integer.MAX_VALUE);
 
         searchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
             @Override

--- a/app/src/main/java/org/apache/fineract/ui/online/teller/TellerFragment.kt
+++ b/app/src/main/java/org/apache/fineract/ui/online/teller/TellerFragment.kt
@@ -109,6 +109,7 @@ class TellerFragment : FineractBaseFragment(), TellerContract.View, SwipeRefresh
         val searchView = menu?.findItem(R.id.teller_search)?.actionView as? SearchView
 
         searchView?.setSearchableInfo(searchManager?.getSearchableInfo(activity?.componentName))
+        searchView?.maxWidth = Int.MAX_VALUE
 
         searchView?.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
             override fun onQueryTextSubmit(query: String): Boolean {

--- a/app/src/main/java/org/apache/fineract/ui/product/ProductFragment.kt
+++ b/app/src/main/java/org/apache/fineract/ui/product/ProductFragment.kt
@@ -105,6 +105,7 @@ class ProductFragment : FineractBaseFragment(), ProductContract.View,
         val searchView = menu?.findItem(R.id.product_search)?.actionView as? SearchView
 
         searchView?.setSearchableInfo(searchManager?.getSearchableInfo(activity?.componentName))
+        searchView?.maxWidth = Int.MAX_VALUE
 
         searchView?.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
             override fun onQueryTextSubmit(query: String): Boolean {


### PR DESCRIPTION
Fixes [FINCN-254](https://issues.apache.org/jira/browse/FINCN-254)

Now all searchbars are in full length.

**Error**

https://user-images.githubusercontent.com/70195106/111027098-259a1780-8414-11eb-9f14-355ff2deed76.mp4

**Solution**

https://user-images.githubusercontent.com/70195106/111027133-4e221180-8414-11eb-8c09-4ac44d71cdc2.mp4



- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.