### PR TITLE
Fix-258: FAB in Manage roles removed

### DIFF
--- a/app/src/main/res/layout/fragment_roles_list.xml
+++ b/app/src/main/res/layout/fragment_roles_list.xml
@@ -23,16 +23,6 @@
         android:id="@+id/layout_error"
         android:visibility="gone"/>
 
-    <com.google.android.material.floatingactionbutton.FloatingActionButton
-        android:clickable="true"
-        android:focusable="true"
-        android:id="@+id/fab_add_role"
-        android:layout_gravity="bottom|end"
-        android:layout_height="wrap_content"
-        android:layout_margin="@dimen/layout_padding_16dp"
-        android:layout_width="wrap_content"
-        app:layout_behavior="org.apache.fineract.utils.ScrollFabBehavior"
-        app:srcCompat="@drawable/ic_add_black_24dp"/>
     <include
         layout="@layout/layout_sweet_exception_handler"
         android:id="@+id/layout_error"


### PR DESCRIPTION
Fixes FINCN-258
As we can't create new roles it unnecessary to keep that fab that doesn't responds.

**Error**

https://user-images.githubusercontent.com/70195106/111077626-adb51580-8517-11eb-82bb-27735d3b98e0.mp4

**Solution**
<img src="https://user-images.githubusercontent.com/70195106/111077663-d9d09680-8517-11eb-96f6-82d5a12565d0.jpeg" width="333"/>

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.