### PR TITLE
Fix-262: Password layout error indicator added in LoginActivity

### DIFF
--- a/app/src/main/java/org/apache/fineract/ui/online/login/LoginActivity.java
+++ b/app/src/main/java/org/apache/fineract/ui/online/login/LoginActivity.java
@@ -6,6 +6,7 @@ import android.text.TextUtils;
 import android.widget.EditText;
 import android.widget.Toast;
 
+import com.google.android.material.textfield.TextInputLayout;
 import com.mifos.mobile.passcode.utils.PassCodeConstants;
 
 import org.apache.fineract.R;
@@ -36,6 +37,9 @@ public class LoginActivity extends FineractBaseActivity implements LoginContract
 
     @BindView(R.id.et_password)
     EditText etPassword;
+
+    @BindView(R.id.password_layout)
+    TextInputLayout passwordLayout;
 
     @Inject
     LoginPresenter loginPresenter;
@@ -73,7 +77,7 @@ public class LoginActivity extends FineractBaseActivity implements LoginContract
 
         String password = etPassword.getEditableText().toString();
         if (TextUtils.isEmpty(password)) {
-            etPassword.setError(getString(R.string.error_password_required));
+            passwordLayout.setError(getString(R.string.error_password_required));
             return;
         }
 

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -81,6 +81,7 @@
                 </com.google.android.material.textfield.TextInputLayout>
 
                 <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/password_layout"
                     android:layout_height="wrap_content"
                     android:layout_width="match_parent"
                     app:passwordToggleEnabled="true">


### PR DESCRIPTION
Fixes [FINCN-262](https://issues.apache.org/jira/browse/FINCN-262)

Now error is shown by `TextInputLayout` instead of `EditText`.

<img src="https://user-images.githubusercontent.com/70195106/111114211-ec36e880-8588-11eb-89cd-9b8f76b5db3b.jpeg" width="333"/>

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.