### PR TITLE
Fix 265: Linear layouts fixed in DebtIncomeReportFragment

### DIFF
--- a/app/src/main/java/org/apache/fineract/ui/online/loanaccounts/debtincomereport/DebtIncomeReportFragment.java
+++ b/app/src/main/java/org/apache/fineract/ui/online/loanaccounts/debtincomereport/DebtIncomeReportFragment.java
@@ -7,6 +7,7 @@ import androidx.recyclerview.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
@@ -49,6 +50,12 @@ public class DebtIncomeReportFragment extends FineractBaseFragment {
 
     @BindView(R.id.rl_is_empty_income)
     RelativeLayout rlIsEmptyIncome;
+
+    @BindView(R.id.ll_debt)
+    LinearLayout llDebt;
+
+    @BindView(R.id.ll_income)
+    LinearLayout llIncome;
 
     View rootView;
 
@@ -112,7 +119,7 @@ public class DebtIncomeReportFragment extends FineractBaseFragment {
 
         if (creditWorthinessSnapshot.getDebts().size() == 0) {
             rlIsEmptyDebt.setVisibility(View.VISIBLE);
-            rvDebt.setVisibility(View.GONE);
+            llDebt.setVisibility(View.GONE);
             rlIsEmptyDebt.getChildAt(0).setVisibility(View.GONE);
             TextView message = (TextView) rlIsEmptyDebt.getChildAt(1);
             message.setText(getString(R.string.empty_debts_to_show));
@@ -120,7 +127,7 @@ public class DebtIncomeReportFragment extends FineractBaseFragment {
 
         if (creditWorthinessSnapshot.getIncomeSources().size() == 0) {
             rlIsEmptyIncome.setVisibility(View.VISIBLE);
-            rvIncome.setVisibility(View.GONE);
+            llIncome.setVisibility(View.GONE);
             rlIsEmptyIncome.getChildAt(0).setVisibility(View.GONE);
             TextView message = (TextView) rlIsEmptyIncome.getChildAt(1);
             message.setText(getString(R.string.empty_income_to_show));

--- a/app/src/main/res/layout/fragment_debt_income_report.xml
+++ b/app/src/main/res/layout/fragment_debt_income_report.xml
@@ -36,12 +36,13 @@
                 xmlns:app="http://schemas.android.com/apk/res-auto"
                 android:background="@color/white"
                 android:id="@+id/cv_financial_products"
-                android:layout_height="match_parent"
+                android:layout_height="wrap_content"
                 android:paddingBottom="@dimen/layout_padding_16dp"
                 android:layout_width="match_parent"
                 android:visibility="visible">
 
                 <LinearLayout
+                    android:id="@+id/ll_debt"
                     android:layout_height="match_parent"
                     android:layout_width="match_parent"
                     android:orientation="vertical">
@@ -109,13 +110,14 @@
                         android:layout_width="match_parent"
                         android:paddingBottom="@dimen/layout_padding_8dp"/>
 
-                    <include
-                        layout="@layout/layout_error"
-                        android:id="@+id/rl_is_empty_debt"
-                        android:paddingBottom="@dimen/layout_padding_8dp"
-                        android:visibility="gone"/>
-
                 </LinearLayout>
+                <include
+                    layout="@layout/layout_error"
+                    android:id="@+id/rl_is_empty_debt"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="@dimen/layout_padding_8dp"
+                    android:visibility="gone"/>
 
             </androidx.cardview.widget.CardView>
 
@@ -135,12 +137,13 @@
                 xmlns:android="http://schemas.android.com/apk/res/android"
                 xmlns:app="http://schemas.android.com/apk/res-auto"
                 android:background="@color/white"
-                android:layout_height="match_parent"
+                android:layout_height="wrap_content"
                 android:layout_marginBottom="@dimen/layout_padding_8dp"
                 android:layout_width="match_parent"
                 android:visibility="visible">
 
                 <LinearLayout
+                    android:id="@+id/ll_income"
                     android:layout_height="match_parent"
                     android:layout_width="match_parent"
                     android:orientation="vertical">
@@ -205,14 +208,15 @@
                         android:layout_width="match_parent"
                         android:paddingBottom="@dimen/layout_padding_8dp"/>
 
-                    <include
-                        layout="@layout/layout_error"
-                        android:id="@+id/rl_is_empty_income"
-                        android:paddingBottom="@dimen/layout_padding_8dp"
-                        android:visibility="gone"/>
-
                 </LinearLayout>
 
+                <include
+                    layout="@layout/layout_error"
+                    android:id="@+id/rl_is_empty_income"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="@dimen/layout_padding_8dp"
+                    android:visibility="gone" />
             </androidx.cardview.widget.CardView>
 
         </LinearLayout>


### PR DESCRIPTION
Fixes [FINCN-265](https://issues.apache.org/jira/browse/FINCN-265)
Now only message is visible. Description and Amount are not shown.

https://user-images.githubusercontent.com/70195106/111137668-11d1eb00-85a5-11eb-8c64-a73aa1ca0b9f.mp4

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.