### PR TITLE
resolve issue of fragment.onRequestPermissionResult not get call

### DIFF
--- a/app/src/main/java/org/apache/fineract/ui/online/customers/customerprofile/CustomerProfileActivity.java
+++ b/app/src/main/java/org/apache/fineract/ui/online/customers/customerprofile/CustomerProfileActivity.java
@@ -25,6 +25,7 @@ import org.apache.fineract.ui.base.FineractBaseActivity;
 import org.apache.fineract.ui.base.Toaster;
 import org.apache.fineract.ui.online.customers.customerprofile.editcustomerprofilebottomsheet
         .EditCustomerProfileBottomSheet;
+import org.apache.fineract.ui.online.customers.customerprofile.editcustomerprofilebottomsheet.EditCustomerProfileContract;
 import org.apache.fineract.ui.refreshcallback.RefreshProfileImage;
 import org.apache.fineract.utils.CheckSelfPermissionAndRequest;
 import org.apache.fineract.utils.ConstantKeys;
@@ -50,6 +51,8 @@ public class CustomerProfileActivity extends FineractBaseActivity
     CoordinatorLayout errorView;
 
     private String customerIdentifier;
+
+    EditCustomerProfileContract.View editProfileListener;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -83,6 +86,7 @@ public class CustomerProfileActivity extends FineractBaseActivity
                 profileBottomSheet.setRefreshProfileImage(this);
                 profileBottomSheet.show(getSupportFragmentManager(),
                         getString(R.string.customer_image));
+                setEditProfileListener(profileBottomSheet);
                 return true;
             case R.id.menu_customer_profile_share:
                 checkCameraPermission();
@@ -90,6 +94,10 @@ public class CustomerProfileActivity extends FineractBaseActivity
             default:
                 return super.onOptionsItemSelected(item);
         }
+    }
+
+    public void setEditProfileListener(EditCustomerProfileContract.View editProfileListener) {
+        this.editProfileListener = editProfileListener;
     }
 
     public void shareImage() {
@@ -156,7 +164,7 @@ public class CustomerProfileActivity extends FineractBaseActivity
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
                                            @NonNull int[] grantResults) {
         switch (requestCode) {
-            case ConstantKeys.PERMISSIONS_REQUEST_CAMERA: {
+            case ConstantKeys.PERMISSIONS_REQUEST_CAMERA:
                 if (grantResults.length > 0
                         && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
                     shareImage();
@@ -164,7 +172,12 @@ public class CustomerProfileActivity extends FineractBaseActivity
                     Toaster.show(findViewById(android.R.id.content),
                             getString(R.string.permission_denied_write));
                 }
-            }
+                break;
+            case ConstantKeys.PERMISSION_REQUEST_ALL:
+            case ConstantKeys.PERMISSION_REQUEST_READ_EXTERNAL_STORAGE:
+                editProfileListener.requestedPermissionResult(requestCode,
+                        permissions, grantResults);
+                break;
         }
     }
 

--- a/app/src/main/java/org/apache/fineract/ui/online/customers/customerprofile/editcustomerprofilebottomsheet/EditCustomerProfileBottomSheet.java
+++ b/app/src/main/java/org/apache/fineract/ui/online/customers/customerprofile/editcustomerprofilebottomsheet/EditCustomerProfileBottomSheet.java
@@ -118,6 +118,32 @@ public class EditCustomerProfileBottomSheet extends FineractBaseBottomSheetDialo
     }
 
     @Override
+    public void requestedPermissionResult(int requestCode, @NonNull String[] permissions,
+                                          @NonNull int[] grantResults) {
+        switch (requestCode) {
+            case ConstantKeys.PERMISSION_REQUEST_ALL:
+                if (grantResults.length > 0
+                        && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                    openCamera();
+                } else {
+                    String permissionDeniedMessage = getString(R.string.permission_denied_write) +
+                            getString(R.string.permission_denied_camera);
+                    Toaster.show(rootView, permissionDeniedMessage);
+                }
+                break;
+
+            case ConstantKeys.PERMISSION_REQUEST_READ_EXTERNAL_STORAGE:
+                if (grantResults.length > 0
+                        && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                    viewGallery();
+                } else {
+                    Toaster.show(rootView, getString(R.string.permission_denied_read));
+                }
+                break;
+        }
+    }
+
+    @Override
     public void showUserInterface() {
         llCamera.setOnClickListener(this);
         llGallery.setOnClickListener(this);
@@ -250,32 +276,6 @@ public class EditCustomerProfileBottomSheet extends FineractBaseBottomSheetDialo
     @Override
     public void showMessage(String message) {
         Toaster.show(rootView, message);
-    }
-
-    @Override
-    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
-            @NonNull int[] grantResults) {
-        switch (requestCode) {
-            case ConstantKeys.PERMISSION_REQUEST_ALL:
-                if (grantResults.length > 0
-                        && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                    openCamera();
-                } else {
-                    String permissionDeniedMessage = getString(R.string.permission_denied_write) +
-                            getString(R.string.permission_denied_camera);
-                    Toaster.show(rootView, permissionDeniedMessage);
-                }
-                break;
-
-            case ConstantKeys.PERMISSION_REQUEST_READ_EXTERNAL_STORAGE:
-                if (grantResults.length > 0
-                        && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                    viewGallery();
-                } else {
-                    Toaster.show(rootView, getString(R.string.permission_denied_read));
-                }
-                break;
-        }
     }
 
     @OnClick(R.id.btn_cancel)

--- a/app/src/main/java/org/apache/fineract/ui/online/customers/customerprofile/editcustomerprofilebottomsheet/EditCustomerProfileContract.java
+++ b/app/src/main/java/org/apache/fineract/ui/online/customers/customerprofile/editcustomerprofilebottomsheet/EditCustomerProfileContract.java
@@ -1,5 +1,7 @@
 package org.apache.fineract.ui.online.customers.customerprofile.editcustomerprofilebottomsheet;
 
+import androidx.annotation.NonNull;
+
 import org.apache.fineract.ui.base.MvpView;
 import org.apache.fineract.ui.refreshcallback.RefreshProfileImage;
 
@@ -12,6 +14,9 @@ import java.io.File;
 public interface EditCustomerProfileContract {
 
     interface View extends MvpView {
+
+        void requestedPermissionResult(int requestCode, @NonNull String[] permissions,
+                                       @NonNull int[] grantResults);
 
         void showUserInterface();
 


### PR DESCRIPTION
Fixes [FINCN-257](https://issues.apache.org/jira/browse/FINCN-257)

https://user-images.githubusercontent.com/56648862/111198166-46fe2d80-85e5-11eb-99f1-3fb01fb85e0b.mp4

Resolved the issue because of which EditCustomerProfileBottomSheet.onRequestPermissionResult() was not getting called. That's the reason why the gallery or camera was not opening directly after granting permission.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.


