### PR TITLE
Fix-269 : Navigation with tabs implemented in all the Edit screens which use StepperLayout

### DIFF
--- a/app/src/main/res/layout/activity_create_customer.xml
+++ b/app/src/main/res/layout/activity_create_customer.xml
@@ -24,7 +24,7 @@
             app:ms_inactiveStepColor="#cccccc"
             app:ms_nextButtonColor="#FFFFFF"
             app:ms_stepperType="tabs"
-            app:ms_tabNavigationEnabled="false"
+            app:ms_tabNavigationEnabled="true"
             app:ms_tabStepDividerWidth="138dp"
             app:ms_stepperFeedbackType="tabs|content|disabled_bottom_navigation"/>
 

--- a/app/src/main/res/layout/activity_create_deposit.xml
+++ b/app/src/main/res/layout/activity_create_deposit.xml
@@ -23,7 +23,7 @@
             app:ms_inactiveStepColor="#cccccc"
             app:ms_nextButtonColor="#FFFFFF"
             app:ms_stepperType="tabs"
-            app:ms_tabNavigationEnabled="false"
+            app:ms_tabNavigationEnabled="true"
             app:ms_tabStepDividerWidth="138dp"
             app:ms_stepperFeedbackType="tabs|content|disabled_bottom_navigation"/>
 

--- a/app/src/main/res/layout/activity_create_group.xml
+++ b/app/src/main/res/layout/activity_create_group.xml
@@ -20,7 +20,7 @@
             app:ms_nextButtonColor="#FFFFFF"
             app:ms_stepperFeedbackType="tabs|content|disabled_bottom_navigation"
             app:ms_stepperType="tabs"
-            app:ms_tabNavigationEnabled="false"
+            app:ms_tabNavigationEnabled="true"
             app:ms_tabStepDividerWidth="138dp" />
 
     </LinearLayout>

--- a/app/src/main/res/layout/activity_create_identification.xml
+++ b/app/src/main/res/layout/activity_create_identification.xml
@@ -23,7 +23,7 @@
             app:ms_inactiveStepColor="#cccccc"
             app:ms_nextButtonColor="#FFFFFF"
             app:ms_stepperType="tabs"
-            app:ms_tabNavigationEnabled="false"
+            app:ms_tabNavigationEnabled="true"
             app:ms_tabStepDividerWidth="138dp"
             app:ms_stepperFeedbackType="tabs|content|disabled_bottom_navigation"/>
 

--- a/app/src/main/res/layout/activity_edit_payroll.xml
+++ b/app/src/main/res/layout/activity_edit_payroll.xml
@@ -24,7 +24,7 @@
             app:ms_inactiveStepColor="#cccccc"
             app:ms_nextButtonColor="#FFFFFF"
             app:ms_stepperType="tabs"
-            app:ms_tabNavigationEnabled="false"
+            app:ms_tabNavigationEnabled="true"
             app:ms_tabStepDividerWidth="138dp"
             app:ms_stepperFeedbackType="tabs|content|disabled_bottom_navigation"/>
 

--- a/app/src/main/res/layout/activity_loan_application.xml
+++ b/app/src/main/res/layout/activity_loan_application.xml
@@ -23,7 +23,7 @@
             app:ms_inactiveStepColor="#cccccc"
             app:ms_nextButtonColor="#FFFFFF"
             app:ms_stepperType="tabs"
-            app:ms_tabNavigationEnabled="false"
+            app:ms_tabNavigationEnabled="true"
             app:ms_tabStepDividerWidth="138dp"
             app:ms_stepperFeedbackType="tabs|content|disabled_bottom_navigation"/>
 


### PR DESCRIPTION
Fixes [FINCN-269](https://issues.apache.org/jira/browse/FINCN-269)

https://user-images.githubusercontent.com/53621853/111288749-7c009380-866a-11eb-8993-a0bf7cfe2a9f.mp4

In Edit Screens implemented with StepperLayout, right now , we can go to other steps(fragments) only by pressing next or back button. I have implemented the feature by which a user can navigate directly to the desired tab by clicking on that tab. Please note that this feature would be implemented in addition to the current workflow ,i.e, after implementation user can navigate through buttons as well as by clicking on the tabs.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.


