### PR TITLE
Fix-276: Principal Amount error fixed in LoanDetailsFragment

### DIFF
--- a/app/src/main/java/org/apache/fineract/ui/online/loanaccounts/loanapplication/loandetails/LoanDetailsFragment.java
+++ b/app/src/main/java/org/apache/fineract/ui/online/loanaccounts/loanapplication/loandetails/LoanDetailsFragment.java
@@ -431,7 +431,7 @@ public class LoanDetailsFragment extends FineractBaseFragment implements Step,
                 ValidationUtil.isEmpty(getActivity(),
                         etPrincipalAmount.getText().toString().trim(), tilPrincipalAmount);
                 return false;
-            } else if (!(minimum <= value)) {
+            } else if (!(minimum < value)) {
                 ValidationUtil.showTextInputLayoutError(tilPrincipalAmount,
                         getString(R.string.value_must_greater_or_equal_to,
                                 Utils.getPrecision(minimum)));


### PR DESCRIPTION
Fixes [FINCN-276](https://issues.apache.org/jira/browse/FINCN-276)

There was `=` with minimum value (which was `0.0`) which lets user create loan with 0 amount.

**Error**

https://user-images.githubusercontent.com/70195106/111354004-df5ee580-86ab-11eb-98a0-98fbd84a9336.mp4

**Solution**

https://user-images.githubusercontent.com/70195106/111354386-467c9a00-86ac-11eb-83e9-4e57983f475d.mp4


- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.