### PR TITLE
Fix-274: Exiting pattern corrected in all the edit screens, implemented with StepperLayout.

### DIFF
--- a/app/src/main/java/org/apache/fineract/ui/online/customers/createcustomer/customeractivity/CreateCustomerActivity.java
+++ b/app/src/main/java/org/apache/fineract/ui/online/customers/createcustomer/customeractivity/CreateCustomerActivity.java
@@ -20,6 +20,7 @@ import org.apache.fineract.ui.online.customers.createcustomer.CustomerAction;
 import org.apache.fineract.ui.online.customers.createcustomer.OnNavigationBarListener;
 import org.apache.fineract.ui.online.customers.customerdetails.CustomerDetailsActivity;
 import org.apache.fineract.utils.ConstantKeys;
+import org.apache.fineract.utils.MaterialDialog;
 
 import java.util.List;
 
@@ -209,5 +210,26 @@ public class CreateCustomerActivity extends FineractBaseActivity
         super.onDestroy();
         stepperLayout.hideProgress();
         createCustomerPresenter.detachView();
+    }
+
+    @Override
+    public void onBackPressed() {
+        if (stepperLayout.getCurrentStepPosition() != 0) {
+            stepperLayout.setCurrentStepPosition(
+                    stepperLayout.getCurrentStepPosition() - 1);
+        } else {
+            new MaterialDialog.Builder()
+                    .init(this)
+                    .setTitle(getString(R.string.dialog_title_confirm_exit))
+                    .setMessage(getString(
+                            R.string.dialog_message_confirmation_exit_create_edit_activity))
+                    .setPositiveButton(getString(R.string.dialog_action_exit),
+                            (dialog, which) -> {
+                                super.onBackPressed();
+                            })
+                    .setNegativeButton(getString(R.string.dialog_action_cancel))
+                    .createMaterialDialog()
+                    .show();
+        }
     }
 }

--- a/app/src/main/java/org/apache/fineract/ui/online/customers/customerpayroll/editcustomerpayroll/EditPayrollActivity.kt
+++ b/app/src/main/java/org/apache/fineract/ui/online/customers/customerpayroll/editcustomerpayroll/EditPayrollActivity.kt
@@ -1,9 +1,11 @@
 package org.apache.fineract.ui.online.customers.customerpayroll.editcustomerpayroll
 
+import android.content.DialogInterface
 import android.os.Bundle
 import android.view.View
 import com.stepstone.stepper.StepperLayout
 import com.stepstone.stepper.VerificationError
+import kotlinx.android.synthetic.main.activity_create_group.*
 import kotlinx.android.synthetic.main.activity_edit_payroll.*
 import org.apache.fineract.R
 import org.apache.fineract.data.models.payroll.PayrollAllocation
@@ -13,6 +15,7 @@ import org.apache.fineract.ui.base.FineractBaseActivity
 import org.apache.fineract.ui.base.Toaster
 import org.apache.fineract.ui.online.accounting.accounts.EditPayrollContract
 import org.apache.fineract.utils.ConstantKeys
+import org.apache.fineract.utils.MaterialDialog
 import javax.inject.Inject
 
 class EditPayrollActivity : FineractBaseActivity(), StepperLayout.StepperListener,
@@ -57,6 +60,23 @@ class EditPayrollActivity : FineractBaseActivity(), StepperLayout.StepperListene
         stepperLayout.setOffscreenPageLimit(stepAdapter.count)
 
         showBackButton()
+    }
+
+    override fun onBackPressed() {
+        if (slCreateGroup.currentStepPosition !== 0) {
+            slCreateGroup.currentStepPosition = slCreateGroup.currentStepPosition - 1
+        } else {
+            MaterialDialog.Builder()
+                    .init(this)
+                    .setTitle(getString(R.string.dialog_title_confirm_exit))
+                    .setMessage(getString(
+                            R.string.dialog_message_confirmation_exit_create_edit_activity))
+                    .setPositiveButton(getString(R.string.dialog_action_exit)
+                    ) { dialog: DialogInterface?, which: Int -> super.onBackPressed() }
+                    .setNegativeButton(getString(R.string.dialog_action_cancel))
+                    .createMaterialDialog()
+                    .show()
+        }
     }
 
     override fun setPayrollConfig(accountNo: String, lastModifiedBy: String,

--- a/app/src/main/java/org/apache/fineract/ui/online/depositaccounts/createdepositaccount/createdepositactivity/CreateDepositActivity.java
+++ b/app/src/main/java/org/apache/fineract/ui/online/depositaccounts/createdepositaccount/createdepositactivity/CreateDepositActivity.java
@@ -16,6 +16,7 @@ import org.apache.fineract.ui.online.depositaccounts.createdepositaccount
         .DepositOnNavigationBarListener;
 import org.apache.fineract.ui.online.depositaccounts.createdepositaccount.DepositOverViewContract;
 import org.apache.fineract.utils.ConstantKeys;
+import org.apache.fineract.utils.MaterialDialog;
 
 import javax.inject.Inject;
 
@@ -79,6 +80,27 @@ public class CreateDepositActivity extends FineractBaseActivity implements
         }
 
         showBackButton();
+    }
+
+    @Override
+    public void onBackPressed() {
+        if (stepperLayout.getCurrentStepPosition() != 0) {
+            stepperLayout.setCurrentStepPosition(
+                    stepperLayout.getCurrentStepPosition() - 1);
+        } else {
+            new MaterialDialog.Builder()
+                    .init(this)
+                    .setTitle(getString(R.string.dialog_title_confirm_exit))
+                    .setMessage(getString(
+                            R.string.dialog_message_confirmation_exit_create_edit_activity))
+                    .setPositiveButton(getString(R.string.dialog_action_exit),
+                            (dialog, which) -> {
+                                super.onBackPressed();
+                            })
+                    .setNegativeButton(getString(R.string.dialog_action_cancel))
+                    .createMaterialDialog()
+                    .show();
+        }
     }
 
     @Override

--- a/app/src/main/java/org/apache/fineract/ui/online/groups/creategroup/CreateGroupActivity.kt
+++ b/app/src/main/java/org/apache/fineract/ui/online/groups/creategroup/CreateGroupActivity.kt
@@ -1,5 +1,6 @@
 package org.apache.fineract.ui.online.groups.creategroup
 
+import android.content.DialogInterface
 import android.os.Bundle
 import android.view.View
 import android.widget.Toast
@@ -15,11 +16,13 @@ import org.apache.fineract.data.models.customer.Address
 import org.apache.fineract.ui.base.FineractBaseActivity
 import org.apache.fineract.ui.base.Toaster
 import org.apache.fineract.ui.online.groups.GroupAction
-import org.apache.fineract.ui.online.groups.grouplist.GroupViewModelFactory
 import org.apache.fineract.ui.online.groups.grouplist.GroupViewModel
+import org.apache.fineract.ui.online.groups.grouplist.GroupViewModelFactory
 import org.apache.fineract.utils.Constants
 import org.apache.fineract.utils.DateUtils
+import org.apache.fineract.utils.MaterialDialog
 import javax.inject.Inject
+
 
 /*
  * Created by saksham on 02/July/2019
@@ -29,6 +32,8 @@ class CreateGroupActivity : FineractBaseActivity(), StepperLayout.StepperListene
 
     private var group = Group()
     private var groupAction = GroupAction.CREATE
+
+    private var isBackPressedOnce:Boolean = false
 
     @Inject
     lateinit var groupViewModelFactory: GroupViewModelFactory
@@ -60,6 +65,23 @@ class CreateGroupActivity : FineractBaseActivity(), StepperLayout.StepperListene
     }
 
     override fun onStepSelected(newStepPosition: Int) {}
+
+    override fun onBackPressed() {
+        if (slCreateGroup.currentStepPosition !== 0) {
+                    slCreateGroup.currentStepPosition = slCreateGroup.currentStepPosition - 1
+        } else {
+            MaterialDialog.Builder()
+                    .init(this)
+                    .setTitle(getString(R.string.dialog_title_confirm_exit))
+                    .setMessage(getString(
+                            R.string.dialog_message_confirmation_exit_create_edit_activity))
+                    .setPositiveButton(getString(R.string.dialog_action_exit)
+                    ) { dialog: DialogInterface?, which: Int -> super.onBackPressed() }
+                    .setNegativeButton(getString(R.string.dialog_action_cancel))
+                    .createMaterialDialog()
+                    .show()
+        }
+    }
 
     override fun onError(verificationError: VerificationError?) {}
 

--- a/app/src/main/java/org/apache/fineract/ui/online/groups/creategroup/CreateGroupActivity.kt
+++ b/app/src/main/java/org/apache/fineract/ui/online/groups/creategroup/CreateGroupActivity.kt
@@ -1,7 +1,7 @@
 package org.apache.fineract.ui.online.groups.creategroup
 
+import android.content.DialogInterface
 import android.os.Bundle
-import android.os.Handler
 import android.view.View
 import android.widget.Toast
 import androidx.lifecycle.Observer
@@ -20,7 +20,9 @@ import org.apache.fineract.ui.online.groups.grouplist.GroupViewModel
 import org.apache.fineract.ui.online.groups.grouplist.GroupViewModelFactory
 import org.apache.fineract.utils.Constants
 import org.apache.fineract.utils.DateUtils
+import org.apache.fineract.utils.MaterialDialog
 import javax.inject.Inject
+
 
 /*
  * Created by saksham on 02/July/2019
@@ -65,13 +67,19 @@ class CreateGroupActivity : FineractBaseActivity(), StepperLayout.StepperListene
     override fun onStepSelected(newStepPosition: Int) {}
 
     override fun onBackPressed() {
-        if(!isBackPressedOnce && slCreateGroup.currentStepPosition != 0 ){
-            slCreateGroup.currentStepPosition = 0
-            isBackPressedOnce = true
-            Handler().postDelayed(
-                    { isBackPressedOnce = false }, 2000)
-        }else{
-            super.onBackPressed()
+        if (slCreateGroup.currentStepPosition !== 0) {
+                    slCreateGroup.currentStepPosition = slCreateGroup.currentStepPosition - 1
+        } else {
+            MaterialDialog.Builder()
+                    .init(this)
+                    .setTitle(getString(R.string.dialog_title_confirm_exit))
+                    .setMessage(getString(
+                            R.string.dialog_message_confirmation_exit_create_edit_activity))
+                    .setPositiveButton(getString(R.string.dialog_action_exit)
+                    ) { dialog: DialogInterface?, which: Int -> super.onBackPressed() }
+                    .setNegativeButton(getString(R.string.dialog_action_cancel))
+                    .createMaterialDialog()
+                    .show()
         }
     }
 

--- a/app/src/main/java/org/apache/fineract/ui/online/groups/creategroup/CreateGroupActivity.kt
+++ b/app/src/main/java/org/apache/fineract/ui/online/groups/creategroup/CreateGroupActivity.kt
@@ -1,6 +1,7 @@
 package org.apache.fineract.ui.online.groups.creategroup
 
 import android.os.Bundle
+import android.os.Handler
 import android.view.View
 import android.widget.Toast
 import androidx.lifecycle.Observer
@@ -15,8 +16,8 @@ import org.apache.fineract.data.models.customer.Address
 import org.apache.fineract.ui.base.FineractBaseActivity
 import org.apache.fineract.ui.base.Toaster
 import org.apache.fineract.ui.online.groups.GroupAction
-import org.apache.fineract.ui.online.groups.grouplist.GroupViewModelFactory
 import org.apache.fineract.ui.online.groups.grouplist.GroupViewModel
+import org.apache.fineract.ui.online.groups.grouplist.GroupViewModelFactory
 import org.apache.fineract.utils.Constants
 import org.apache.fineract.utils.DateUtils
 import javax.inject.Inject
@@ -29,6 +30,8 @@ class CreateGroupActivity : FineractBaseActivity(), StepperLayout.StepperListene
 
     private var group = Group()
     private var groupAction = GroupAction.CREATE
+
+    private var isBackPressedOnce:Boolean = false
 
     @Inject
     lateinit var groupViewModelFactory: GroupViewModelFactory
@@ -60,6 +63,17 @@ class CreateGroupActivity : FineractBaseActivity(), StepperLayout.StepperListene
     }
 
     override fun onStepSelected(newStepPosition: Int) {}
+
+    override fun onBackPressed() {
+        if(!isBackPressedOnce && slCreateGroup.currentStepPosition != 0 ){
+            slCreateGroup.currentStepPosition = 0
+            isBackPressedOnce = true
+            Handler().postDelayed(
+                    { isBackPressedOnce = false }, 2000)
+        }else{
+            super.onBackPressed()
+        }
+    }
 
     override fun onError(verificationError: VerificationError?) {}
 

--- a/app/src/main/java/org/apache/fineract/ui/online/identification/createidentification/identificationactivity/CreateIdentificationActivity.java
+++ b/app/src/main/java/org/apache/fineract/ui/online/identification/createidentification/identificationactivity/CreateIdentificationActivity.java
@@ -18,6 +18,7 @@ import org.apache.fineract.ui.online.identification.createidentification.Action;
 import org.apache.fineract.ui.online.identification.createidentification.OnNavigationBarListener;
 import org.apache.fineract.ui.online.identification.createidentification.OverViewContract;
 import org.apache.fineract.utils.ConstantKeys;
+import org.apache.fineract.utils.MaterialDialog;
 
 import javax.inject.Inject;
 
@@ -82,6 +83,27 @@ public class CreateIdentificationActivity extends FineractBaseActivity
         }
 
         showBackButton();
+    }
+
+    @Override
+    public void onBackPressed() {
+        if (stepperLayout.getCurrentStepPosition() != 0) {
+            stepperLayout.setCurrentStepPosition(
+                    stepperLayout.getCurrentStepPosition() - 1);
+        } else {
+            new MaterialDialog.Builder()
+                    .init(this)
+                    .setTitle(getString(R.string.dialog_title_confirm_exit))
+                    .setMessage(getString(
+                            R.string.dialog_message_confirmation_exit_create_edit_activity))
+                    .setPositiveButton(getString(R.string.dialog_action_exit),
+                            (dialog, which) -> {
+                                super.onBackPressed();
+                            })
+                    .setNegativeButton(getString(R.string.dialog_action_cancel))
+                    .createMaterialDialog()
+                    .show();
+        }
     }
 
     @Override

--- a/app/src/main/java/org/apache/fineract/ui/online/loanaccounts/loanapplication/loanactivity/LoanApplicationActivity.java
+++ b/app/src/main/java/org/apache/fineract/ui/online/loanaccounts/loanapplication/loanactivity/LoanApplicationActivity.java
@@ -19,6 +19,7 @@ import org.apache.fineract.ui.base.FineractBaseActivity;
 import org.apache.fineract.ui.base.Toaster;
 import org.apache.fineract.ui.online.loanaccounts.loanapplication.OnNavigationBarListener;
 import org.apache.fineract.utils.ConstantKeys;
+import org.apache.fineract.utils.MaterialDialog;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -77,6 +78,27 @@ public class LoanApplicationActivity extends FineractBaseActivity
         stepperLayout.setOffscreenPageLimit(stepAdapter.getCount());
         setToolbarTitle(getString(R.string.create_new_loan));
         showBackButton();
+    }
+
+    @Override
+    public void onBackPressed() {
+        if (stepperLayout.getCurrentStepPosition() != 0) {
+            stepperLayout.setCurrentStepPosition(
+                    stepperLayout.getCurrentStepPosition() - 1);
+        } else {
+            new MaterialDialog.Builder()
+                    .init(this)
+                    .setTitle(getString(R.string.dialog_title_confirm_exit))
+                    .setMessage(getString(
+                            R.string.dialog_message_confirmation_exit_create_edit_activity))
+                    .setPositiveButton(getString(R.string.dialog_action_exit),
+                            (dialog, which) -> {
+                                super.onBackPressed();
+                            })
+                    .setNegativeButton(getString(R.string.dialog_action_cancel))
+                    .createMaterialDialog()
+                    .show();
+        }
     }
 
     @Override

--- a/app/src/main/res/values-ml-rIN/strings.xml
+++ b/app/src/main/res/values-ml-rIN/strings.xml
@@ -258,6 +258,7 @@
     <string name="error_fetching_customer_details">ഉപഭോക്തൃ വിശദാംശങ്ങൾ ലഭ്യമാക്കുന്നതിൽ പരാജയപ്പെട്ടു</string>
     <string name="error_fetching_deposit_product">ഡെപ്പോസിറ്റ് ഉൽപ്പന്നം ലഭ്യമാക്കുന്നത് പരാജയപ്പെട്ടു</string>
     <string name="error_failed_to_refresh_customers">ഉപയോക്താക്കളെ പുതുക്കുന്നതിന് പരാജയപ്പെട്ടു</string>
+    <string name="dialog_action_exit">പുറത്ത്</string>
     <string name="dialog_action_ok">ശരി</string>
     <string name="dialog_action_cancel">റദ്ദാക്കുക</string>
     <string name="dialog_action_back">തിരികെ</string>
@@ -269,6 +270,8 @@
     <string name="dialog_action_logout">പുറത്തുകടക്കുക</string>
     <string name="dialog_title_confirm_deletion">ഇല്ലാതാക്കൽ സ്ഥിരീകരിക്കുക</string>
     <string name="dialog_title_confirm_logout">ലോഗ്ഔട്ട് സ്ഥിരീകരിക്കുക</string>
+    <string name="dialog_title_confirm_exit">എക്സിറ്റ് സ്ഥിരീകരിക്കുക</string>
+    <string name="dialog_message_confirmation_exit_create_edit_activity">നിങ്ങള്ക്ക് ഉറപ്പാണോ? പുറത്തുകടക്കുന്നത് സാധ്യമായ എല്ലാ മാറ്റങ്ങളും ഉപേക്ഷിക്കും</string>
     <string name="dialog_message_confirmation_delete_identification_card">ഈ തിരിച്ചറിയൽ കാർഡ് ഇല്ലാതാക്കാൻ ആഗ്രഹിക്കുന്നുവോ?</string>
     <string name="dialog_message_confirmation_delete_identification_card_scan">ഈ ഐഡന്റിഫിക്കേഷൻ കാർഡ് സ്കാൻ ഇല്ലാതാക്കാൻ നിങ്ങൾക്ക് താൽപ്പര്യമുണ്ടോ?</string>
     <string name="dialog_message_confirmation_logout">നിങ്ങള്ക്ക് ഉറപ്പാണോ? നിങ്ങൾ പുറത്തുകടക്കാൻ ആഗ്രഹിക്കുന്നു</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -325,6 +325,7 @@
     <string name="error_group_atleast_1_leader">Group should have atleast 1 Leader</string>
 
     <!--Material Dialog-->
+    <string name="dialog_action_exit">Exit</string>
     <string name="dialog_action_ok">OK</string>
     <string name="dialog_action_cancel">Cancel</string>
     <string name="dialog_action_back">Back</string>
@@ -336,6 +337,8 @@
     <string name="dialog_action_logout">Logout</string>
     <string name="dialog_title_confirm_deletion">Confirm deletion</string>
     <string name="dialog_title_confirm_logout">Confirm logout</string>
+    <string name="dialog_title_confirm_exit">Confirm exit</string>
+    <string name="dialog_message_confirmation_exit_create_edit_activity">Are you sure? exiting will discard all possible changes</string>
     <string name="dialog_message_confirmation_delete_identification_card">Do you want to delete this identification card?</string>
     <string name="dialog_message_confirmation_delete_identification_card_scan">Do you want to delete this identification card scan?</string>
     <string name="dialog_message_confirmation_logout">Are you sure? you want to logout</string>


### PR DESCRIPTION
Fixes [FINCN-274](https://issues.apache.org/jira/browse/FINCN-274)

Before fix: 

https://user-images.githubusercontent.com/53621853/111363047-8e53ef00-86b5-11eb-904c-a3311a439bf2.mp4

After fix: 


https://user-images.githubusercontent.com/53621853/111411727-16131b00-8701-11eb-983d-4699f2aa618f.mp4


In all Edit screen , the StepperLyaout has been implemented and right now, if the user presses back button, no matter if the user is on 3rd page or editing something, he will directly exit the edit screen.

After Fix: Now , the user will be taken to the previous tab of editing screen and then after again pressing back button he will see a dialog box confirming to exit .

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.


