### PR TITLE
resolve the bad CreateCustomerActivity exit pattern

### DIFF
--- a/app/src/main/java/org/apache/fineract/ui/online/customers/createcustomer/customeractivity/CreateCustomerActivity.java
+++ b/app/src/main/java/org/apache/fineract/ui/online/customers/createcustomer/customeractivity/CreateCustomerActivity.java
@@ -20,6 +20,7 @@ import org.apache.fineract.ui.online.customers.createcustomer.CustomerAction;
 import org.apache.fineract.ui.online.customers.createcustomer.OnNavigationBarListener;
 import org.apache.fineract.ui.online.customers.customerdetails.CustomerDetailsActivity;
 import org.apache.fineract.utils.ConstantKeys;
+import org.apache.fineract.utils.MaterialDialog;
 
 import java.util.List;
 
@@ -209,5 +210,26 @@ public class CreateCustomerActivity extends FineractBaseActivity
         super.onDestroy();
         stepperLayout.hideProgress();
         createCustomerPresenter.detachView();
+    }
+
+    @Override
+    public void onBackPressed() {
+        if (stepperLayout.getCurrentStepPosition() != 0) {
+            stepperLayout.setCurrentStepPosition(
+                    stepperLayout.getCurrentStepPosition() - 1);
+        } else {
+            new MaterialDialog.Builder()
+                    .init(this)
+                    .setTitle(getString(R.string.dialog_title_confirm_exit))
+                    .setMessage(getString(
+                            R.string.dialog_message_confirmation_exit_create_edit_activity))
+                    .setPositiveButton(getString(R.string.dialog_action_exit),
+                            (dialog, which) -> {
+                                super.onBackPressed();
+                            })
+                    .setNegativeButton(getString(R.string.dialog_action_cancel))
+                    .createMaterialDialog()
+                    .show();
+        }
     }
 }

--- a/app/src/main/res/values-ml-rIN/strings.xml
+++ b/app/src/main/res/values-ml-rIN/strings.xml
@@ -258,6 +258,7 @@
     <string name="error_fetching_customer_details">ഉപഭോക്തൃ വിശദാംശങ്ങൾ ലഭ്യമാക്കുന്നതിൽ പരാജയപ്പെട്ടു</string>
     <string name="error_fetching_deposit_product">ഡെപ്പോസിറ്റ് ഉൽപ്പന്നം ലഭ്യമാക്കുന്നത് പരാജയപ്പെട്ടു</string>
     <string name="error_failed_to_refresh_customers">ഉപയോക്താക്കളെ പുതുക്കുന്നതിന് പരാജയപ്പെട്ടു</string>
+    <string name="dialog_action_exit">പുറത്ത്</string>
     <string name="dialog_action_ok">ശരി</string>
     <string name="dialog_action_cancel">റദ്ദാക്കുക</string>
     <string name="dialog_action_back">തിരികെ</string>
@@ -269,6 +270,8 @@
     <string name="dialog_action_logout">പുറത്തുകടക്കുക</string>
     <string name="dialog_title_confirm_deletion">ഇല്ലാതാക്കൽ സ്ഥിരീകരിക്കുക</string>
     <string name="dialog_title_confirm_logout">ലോഗ്ഔട്ട് സ്ഥിരീകരിക്കുക</string>
+    <string name="dialog_title_confirm_exit">എക്സിറ്റ് സ്ഥിരീകരിക്കുക</string>
+    <string name="dialog_message_confirmation_exit_create_edit_activity">നിങ്ങള്ക്ക് ഉറപ്പാണോ? പുറത്തുകടക്കുന്നത് സാധ്യമായ എല്ലാ മാറ്റങ്ങളും ഉപേക്ഷിക്കും</string>
     <string name="dialog_message_confirmation_delete_identification_card">ഈ തിരിച്ചറിയൽ കാർഡ് ഇല്ലാതാക്കാൻ ആഗ്രഹിക്കുന്നുവോ?</string>
     <string name="dialog_message_confirmation_delete_identification_card_scan">ഈ ഐഡന്റിഫിക്കേഷൻ കാർഡ് സ്കാൻ ഇല്ലാതാക്കാൻ നിങ്ങൾക്ക് താൽപ്പര്യമുണ്ടോ?</string>
     <string name="dialog_message_confirmation_logout">നിങ്ങള്ക്ക് ഉറപ്പാണോ? നിങ്ങൾ പുറത്തുകടക്കാൻ ആഗ്രഹിക്കുന്നു</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -325,6 +325,7 @@
     <string name="error_group_atleast_1_leader">Group should have atleast 1 Leader</string>
 
     <!--Material Dialog-->
+    <string name="dialog_action_exit">Exit</string>
     <string name="dialog_action_ok">OK</string>
     <string name="dialog_action_cancel">Cancel</string>
     <string name="dialog_action_back">Back</string>
@@ -336,6 +337,8 @@
     <string name="dialog_action_logout">Logout</string>
     <string name="dialog_title_confirm_deletion">Confirm deletion</string>
     <string name="dialog_title_confirm_logout">Confirm logout</string>
+    <string name="dialog_title_confirm_exit">Confirm exit</string>
+    <string name="dialog_message_confirmation_exit_create_edit_activity">Are you sure? exiting will discard all possible changes</string>
     <string name="dialog_message_confirmation_delete_identification_card">Do you want to delete this identification card?</string>
     <string name="dialog_message_confirmation_delete_identification_card_scan">Do you want to delete this identification card scan?</string>
     <string name="dialog_message_confirmation_logout">Are you sure? you want to logout</string>


### PR DESCRIPTION
Fixes [FINCN-277](https://issues.apache.org/jira/browse/FINCN-277)

https://user-images.githubusercontent.com/56648862/111373087-813cfd00-86c1-11eb-8953-92c641674477.mp4

Made the customer create and edit activity's exit experience better

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.


