### PR TITLE
Fix-280: Filter results and empty customers fixed in CustomersFragment

### DIFF
--- a/app/src/main/java/org/apache/fineract/ui/online/customers/customerlist/CustomersFragment.java
+++ b/app/src/main/java/org/apache/fineract/ui/online/customers/customerlist/CustomersFragment.java
@@ -6,6 +6,7 @@ import android.app.SearchManager;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+
 import androidx.annotation.Nullable;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import androidx.transition.TransitionManager;
@@ -13,6 +14,7 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.appcompat.widget.SearchView;
+
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -193,8 +195,7 @@ public class CustomersFragment extends FineractBaseFragment implements Customers
     public void showEmptyCustomers(String message) {
         showRecyclerView(false);
         sweetUIErrorHandler.showSweetCustomErrorUI(getString(R.string.customer),
-                getString(Integer.parseInt(message)),
-                R.drawable.ic_customer_black_24dp, rvCustomers, layoutError);
+                message, R.drawable.ic_customer_black_24dp, rvCustomers, layoutError);
     }
 
     @Override
@@ -225,7 +226,12 @@ public class CustomersFragment extends FineractBaseFragment implements Customers
 
     @Override
     public void searchCustomerList(Customer customer) {
-        customerAdapter.setCustomers(Collections.singletonList(customer));
+        if (customer.getIdentifier() != null && !customer.getIdentifier().isEmpty()) {
+            customerAdapter.setCustomers(Collections.singletonList(customer));
+        } else {
+            customerAdapter.setCustomers(new ArrayList<Customer>());
+            showEmptyCustomers(getString(R.string.empty_customer_list));
+        }
     }
 
     @Override
@@ -299,6 +305,7 @@ public class CustomersFragment extends FineractBaseFragment implements Customers
                 rgSearch.clearCheck();
                 TransitionManager.beginDelayedTransition(coordinator);
                 llSearch.setVisibility(View.GONE);
+                sweetUIErrorHandler.hideSweetErrorLayoutUI(rvCustomers, layoutError);
                 return false;
             }
         });


### PR DESCRIPTION
Fixes [FINCN-280](https://issues.apache.org/jira/browse/FINCN-280)

Now filter results shows empty list instead of null customer and also emptycustomer method has been fixed to stop crashing and also there as flaw in searchview. If searchview closes and error screen is still visible it will remain visible even on closing search view. It has also been fixed.

https://user-images.githubusercontent.com/70195106/111434467-96e40e00-8725-11eb-89fd-bdf6ba8fc49b.mp4



- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.