### PR TITLE
Fix 285: Identification date and layout fixed in FormIdentificationDetailsFragment

### DIFF
--- a/app/src/main/java/org/apache/fineract/ui/online/identification/createidentification/FormIdentificationDetailsFragment.java
+++ b/app/src/main/java/org/apache/fineract/ui/online/identification/createidentification/FormIdentificationDetailsFragment.java
@@ -144,9 +144,11 @@ public class FormIdentificationDetailsFragment extends FineractBaseFragment impl
 
     @OnClick(R.id.et_expiration_date)
     void onClickDateOfBirth() {
-        new DatePickerDialog(getActivity(), date, calendar
+        DatePickerDialog datePickerDialog = new DatePickerDialog(getActivity(), date, calendar
                 .get(Calendar.YEAR), calendar.get(Calendar.MONTH),
-                calendar.get(Calendar.DAY_OF_MONTH)).show();
+                calendar.get(Calendar.DAY_OF_MONTH));
+        datePickerDialog.getDatePicker().setMinDate(System.currentTimeMillis());
+        datePickerDialog.show();
     }
 
     private void setDateOfBirth() {
@@ -193,8 +195,6 @@ public class FormIdentificationDetailsFragment extends FineractBaseFragment impl
             validateNumber();
         } else if (etType.getText().hashCode() == s.hashCode()) {
             validateType();
-        } else if (etExpirationDate.getText().hashCode() == s.hashCode()) {
-            validateExpirationDate();
         } else if (etIssuer.getText().hashCode() == s.hashCode()) {
             validateIssuer();
         }


### PR DESCRIPTION
Fixes [FINCN-285](https://issues.apache.org/jira/browse/FINCN-285)
Now user cannot select expiration date before current date and also error is not shown before selecting date

**Error**

https://user-images.githubusercontent.com/70195106/111464410-bfc8cb00-8746-11eb-9ec2-a934c6d946c7.mp4

**Solution**

https://user-images.githubusercontent.com/70195106/111464623-01f20c80-8747-11eb-96b6-71bfe3435f76.mp4


- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.