### PR TITLE
Fix-288: Direct exit from Camera, Gallery fixed in EditCustomerProfileBottomSheet

### DIFF
--- a/app/src/main/java/org/apache/fineract/ui/online/customers/customerprofile/editcustomerprofilebottomsheet/EditCustomerProfileBottomSheet.java
+++ b/app/src/main/java/org/apache/fineract/ui/online/customers/customerprofile/editcustomerprofilebottomsheet/EditCustomerProfileBottomSheet.java
@@ -13,9 +13,12 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.provider.MediaStore;
+
 import androidx.annotation.NonNull;
+
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
 import com.google.android.material.bottomsheet.BottomSheetDialog;
+
 import android.view.View;
 import android.widget.Button;
 import android.widget.LinearLayout;
@@ -280,7 +283,12 @@ public class EditCustomerProfileBottomSheet extends FineractBaseBottomSheetDialo
 
     @OnClick(R.id.btn_cancel)
     void onCancel() {
-        dismiss();
+        llEditActions.setVisibility(View.VISIBLE);
+        llEditActionForm.setVisibility(View.GONE);
+        ivCustomerPicture.setImageDrawable(
+                getResources().getDrawable(R.drawable.ic_account_circle_black_24dp));
+        file = null;
+        tvImageName.setText(R.string.no_file_selected_yet);
     }
 
     @OnClick(R.id.btn_upload_photo)
@@ -319,6 +327,12 @@ public class EditCustomerProfileBottomSheet extends FineractBaseBottomSheetDialo
             ivCustomerPicture.setImageBitmap(imageBitmap);
 
             showImageSizeExceededOrNot();
+            tvHeader.setText(R.string.camera);
+            btnChooseSelectPhoto.setText(R.string.retake_photo);
+            btnChooseSelectPhoto.setCompoundDrawablesWithIntrinsicBounds(
+                    R.drawable.ic_camera_enhance_black_24dp, 0, 0, 0);
+            llEditActions.setVisibility(View.GONE);
+            llEditActionForm.setVisibility(View.VISIBLE);
 
         } else if (requestCode == REQUEST_PHOTO_FROM_GALLERY && resultCode == Activity.RESULT_OK) {
             if (data == null) {
@@ -335,20 +349,17 @@ public class EditCustomerProfileBottomSheet extends FineractBaseBottomSheetDialo
 
     @Override
     public void onClick(View v) {
-        llEditActions.setVisibility(View.GONE);
-        llEditActionForm.setVisibility(View.VISIBLE);
         switch (v.getId()) {
             case R.id.ll_gallery:
                 editAction = EditAction.GALLERY;
                 tvHeader.setText(R.string.gallery);
                 btnChooseSelectPhoto.setText(R.string.choose_file);
+                llEditActions.setVisibility(View.GONE);
+                llEditActionForm.setVisibility(View.VISIBLE);
                 break;
             case R.id.ll_camera:
+                openCamera();
                 editAction = EditAction.CAMERA;
-                tvHeader.setText(R.string.camera);
-                btnChooseSelectPhoto.setText(R.string.take_photo);
-                btnChooseSelectPhoto.setCompoundDrawablesWithIntrinsicBounds(
-                        R.drawable.ic_camera_enhance_black_24dp, 0, 0, 0);
                 break;
             case R.id.ll_delete:
                 editAction = EditAction.DELETE;

--- a/app/src/main/res/values-ml-rIN/strings.xml
+++ b/app/src/main/res/values-ml-rIN/strings.xml
@@ -154,7 +154,7 @@
     <string name="edit_selected_file">തിരഞ്ഞെടുത്ത ഫയൽ:</string>
     <string name="no_file_selected_yet">ഇതുവരെ ഫയൽ തിരഞ്ഞെടുത്തിട്ടില്ല.</string>
     <string name="choose_file">ഒരു ഫയൽ തിരഞ്ഞെടുക്കുക (പരമാവധി വലിപ്പം 512 KB)</string>
-    <string name="take_photo">ഫോട്ടോ എടുക്കുക (പരമാവധി വലുപ്പം 512 KB)</string>
+    <string name="retake_photo">ഫോട്ടോ എടുക്കുക (പരമാവധി വലുപ്പം 512 KB)</string>
     <string name="are_sure_want_remove_portrait">നിങ്ങള്ക്ക് ഉറപ്പാണോ? നിങ്ങൾ പോർട്രെയ്റ്റ് ഇല്ലാതാക്കാൻ ആഗ്രഹിക്കുന്നു.</string>
     <string name="delete">ഇല്ലാതാക്കുക</string>
     <string name="uploading_portrait">പോർട്രെയ്റ്റ് അപ്ലോഡുചെയ്യുന്നത് ദയവായി കാത്തിരിക്കുക ...</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -168,7 +168,7 @@
     <string name="edit_selected_file">Selected file:</string>
     <string name="no_file_selected_yet">No file selected yet.</string>
     <string name="choose_file">Choose a file (max size 512 KB)</string>
-    <string name="take_photo">Take photo (max size 512 KB)</string>
+    <string name="retake_photo">Retake photo (max size 512 KB)</string>
     <string name="are_sure_want_remove_portrait">Are you sure? you want to delete portrait.</string>
     <string name="delete">Delete</string>
     <string name="uploading_portrait">Uploading portrait please wait…</string>


### PR DESCRIPTION
Fixes [FINCN-288](https://issues.apache.org/jira/browse/FINCN-288)

Now camera directly opens for camera option, also if **cancel** is clicked initial bottomsheet opens instead of closing sheet.

**Error**

https://user-images.githubusercontent.com/70195106/111476227-f9ec9980-8753-11eb-950c-ffeb491237c9.mp4

**Solution**

https://user-images.githubusercontent.com/70195106/111476050-c1e55680-8753-11eb-9fc5-83ca73ff44dc.mp4


- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.