### PR TITLE
Fix-301: Whitespace and trim members/leaders fixed in Group

### DIFF
--- a/app/src/main/java/org/apache/fineract/ui/online/groups/creategroup/AddGroupLeaderStepFragment.kt
+++ b/app/src/main/java/org/apache/fineract/ui/online/groups/creategroup/AddGroupLeaderStepFragment.kt
@@ -14,7 +14,6 @@ import com.stepstone.stepper.VerificationError
 import com.wajahatkarim3.easyvalidation.core.view_ktx.validator
 import kotlinx.android.synthetic.main.fragment_step_add_group_leader.*
 import kotlinx.android.synthetic.main.fragment_step_add_group_leader.view.*
-import kotlinx.android.synthetic.main.fragment_step_add_group_member.view.*
 import kotlinx.android.synthetic.main.fragment_step_add_group_member.view.rv_name
 import org.apache.fineract.R
 import org.apache.fineract.ui.adapters.NameListAdapter
@@ -104,14 +103,19 @@ class AddGroupLeaderStepFragment : FineractBaseFragment(), Step, NameListAdapter
     @Optional
     @OnClick(R.id.btnAddLeader)
     fun addLeader() {
+        if (etNewLeader.text.toString().trim().isEmpty()) {
+            etNewLeader.error = getString(R.string.leader_member_empty,
+                    getString(R.string.leaders))
+            return
+        }
         if (etNewLeader.validator()
                         .nonEmpty()
                         .noNumbers()
                         .addErrorCallback { etNewLeader.error = it }.check()) {
             if (currentAction == GroupAction.CREATE) {
-                leaders.add(etNewLeader.text.toString())
+                leaders.add(etNewLeader.text.toString().trim())
             } else {
-                leaders[editItemPosition] = etNewLeader.text.toString()
+                leaders[editItemPosition] = etNewLeader.text.toString().trim()
             }
             etNewLeader.text.clear()
             llAddLeader.visibility = View.GONE

--- a/app/src/main/java/org/apache/fineract/ui/online/groups/creategroup/AddGroupMemberStepFragment.kt
+++ b/app/src/main/java/org/apache/fineract/ui/online/groups/creategroup/AddGroupMemberStepFragment.kt
@@ -102,14 +102,19 @@ class AddGroupMemberStepFragment : FineractBaseFragment(), Step, NameListAdapter
     @Optional
     @OnClick(R.id.btnAddMember)
     fun addMember() {
+        if (etNewMember.text.toString().trim().isEmpty()) {
+            etNewMember.error = getString(R.string.leader_member_empty,
+                    getString(R.string.members))
+            return
+        }
         if (etNewMember.validator()
                         .nonEmpty()
                         .noNumbers()
                         .addErrorCallback { etNewMember.error = it }.check()) {
             if (currentAction == GroupAction.CREATE) {
-                members.add(etNewMember.text.toString())
+                members.add(etNewMember.text.toString().trim())
             } else {
-                members[editItemPosition] = etNewMember.text.toString()
+                members[editItemPosition] = etNewMember.text.toString().trim()
             }
             etNewMember.text.clear()
             llAddMember.visibility = View.GONE

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -280,6 +280,7 @@
     <string name="two_warning_message">%1$s \n %1$s</string>
     <string name="invalid_country">Invalid country</string>
     <string name="invalid_email">Invalid email</string>
+    <string name="leader_member_empty">%s name cannot be empty</string>
 
 
     <!--Error Message-->


### PR DESCRIPTION
Fixes [FINCN-301](https://issues.apache.org/jira/browse/FINCN-301)
Now only whitespaces are not allowed in members. Also **name is trimmed to avoid extra spaces**.

https://user-images.githubusercontent.com/70195106/111875288-00327e00-89bf-11eb-84ea-48163fa0ac95.mp4


- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.