### PR TITLE
Fix-305: Checkbox replaced with Icons for proportionality field in Edit payroll Screen

### DIFF
--- a/app/src/main/java/org/apache/fineract/ui/adapters/PayrollAllocationAdapter.kt
+++ b/app/src/main/java/org/apache/fineract/ui/adapters/PayrollAllocationAdapter.kt
@@ -31,10 +31,10 @@ class PayrollAllocationAdapter @Inject constructor()
         holder.tvAmount.text = amount.toString()
         if (proportional) {
             holder.ivproportional_checked.visibility = View.VISIBLE
-            holder.ivproportional_crossed.visibility= View.GONE
-        }else {
+            holder.ivproportional_crossed.visibility = View.GONE
+        } else {
             holder.ivproportional_checked.visibility = View.GONE
-            holder.ivproportional_crossed.visibility= View.VISIBLE
+            holder.ivproportional_crossed.visibility = View.VISIBLE
         }
     }
 
@@ -59,7 +59,7 @@ class PayrollAllocationAdapter @Inject constructor()
         val tvAmount: TextView = itemView.tv_amount
 
         val ivproportional_checked: ImageView = itemView.iv_proportional_checked
-        val ivproportional_crossed : ImageView = itemView.iv_proportional_crossed
+        val ivproportional_crossed: ImageView = itemView.iv_proportional_crossed
 
         init {
             ivEdit.setOnClickListener {

--- a/app/src/main/java/org/apache/fineract/ui/adapters/PayrollAllocationAdapter.kt
+++ b/app/src/main/java/org/apache/fineract/ui/adapters/PayrollAllocationAdapter.kt
@@ -1,5 +1,6 @@
 package org.apache.fineract.ui.adapters
 
+import android.opengl.Visibility
 import androidx.recyclerview.widget.RecyclerView
 import android.view.LayoutInflater
 import android.view.View
@@ -28,7 +29,13 @@ class PayrollAllocationAdapter @Inject constructor()
         val (accountNumber, amount, proportional) = payrollAllocation[position]
         holder.tvAccount.text = accountNumber
         holder.tvAmount.text = amount.toString()
-        holder.cbProportional.isChecked = proportional
+        if (proportional) {
+            holder.ivproportional_checked.visibility = View.VISIBLE
+            holder.ivproportional_crossed.visibility= View.GONE
+        }else {
+            holder.ivproportional_checked.visibility = View.GONE
+            holder.ivproportional_crossed.visibility= View.VISIBLE
+        }
     }
 
     override fun getItemCount(): Int {
@@ -50,7 +57,9 @@ class PayrollAllocationAdapter @Inject constructor()
         val ivDelete: ImageView = itemView.iv_delete
         val tvAccount: TextView = itemView.tv_account
         val tvAmount: TextView = itemView.tv_amount
-        val cbProportional: CheckBox = itemView.cb_Proportional
+
+        val ivproportional_checked: ImageView = itemView.iv_proportional_checked
+        val ivproportional_crossed : ImageView = itemView.iv_proportional_crossed
 
         init {
             ivEdit.setOnClickListener {

--- a/app/src/main/res/drawable/ic_cross_cricle_red_24dp.xml
+++ b/app/src/main/res/drawable/ic_cross_cricle_red_24dp.xml
@@ -1,9 +1,9 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
-    android:viewportWidth="24.0"
-    android:viewportHeight="24.0">
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
     <path
         android:fillColor="@color/red_dark"
-        android:pathData="M12,2C6.47,2 2,6.47 2,12s4.47,10 10,10 10,-4.47 10,-10S17.53,2 12,2zM17,15.59L15.59,17 12,13.41 8.41,17 7,15.59 10.59,12 7,8.41 8.41,7 12,10.59 15.59,7 17,8.41 13.41,12 17,15.59z"/>
+        android:pathData="M12,2C6.47,2 2,6.47 2,12s4.47,10 10,10 10,-4.47 10,-10S17.53,2 12,2zM17,15.59L15.59,17 12,13.41 8.41,17 7,15.59 10.59,12 7,8.41 8.41,7 12,10.59 15.59,7 17,8.41 13.41,12 17,15.59z" />
 </vector>

--- a/app/src/main/res/drawable/ic_cross_cricle_red_24dp.xml
+++ b/app/src/main/res/drawable/ic_cross_cricle_red_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="@color/red_dark"
+        android:pathData="M12,2C6.47,2 2,6.47 2,12s4.47,10 10,10 10,-4.47 10,-10S17.53,2 12,2zM17,15.59L15.59,17 12,13.41 8.41,17 7,15.59 10.59,12 7,8.41 8.41,7 12,10.59 15.59,7 17,8.41 13.41,12 17,15.59z"/>
+</vector>

--- a/app/src/main/res/layout/item_payroll_allocation.xml
+++ b/app/src/main/res/layout/item_payroll_allocation.xml
@@ -109,15 +109,35 @@
 
         </LinearLayout>
 
-        <CheckBox
-            android:id="@+id/cb_Proportional"
+        <LinearLayout
+            android:orientation="horizontal"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginLeft="@dimen/layout_padding_16dp"
             android:layout_marginStart="@dimen/layout_padding_16dp"
-            android:layout_marginTop="@dimen/layout_padding_16dp"
-            android:clickable="false"
-            android:text="@string/proportional" />
+            android:layout_marginTop="@dimen/layout_padding_16dp">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/proportional"
+                android:textSize="15sp"/>
+
+            <ImageView
+                android:id="@+id/iv_proportional_checked"
+                android:layout_height="20dp"
+                android:layout_width="wrap_content"
+                android:paddingLeft="5dp"
+                app:srcCompat="@drawable/ic_check_circle_black_24dp"/>
+
+            <ImageView
+                android:id="@+id/iv_proportional_crossed"
+                android:layout_height="20dp"
+                android:layout_width="wrap_content"
+                android:paddingLeft="5dp"
+                app:srcCompat="@drawable/ic_cross_cricle_red_24dp"/>
+
+        </LinearLayout>
 
         <View
             android:layout_width="match_parent"


### PR DESCRIPTION
Fixes [FINCN-305](https://issues.apache.org/jira/browse/FINCN-305)

In the Edit payroll screen, The checkbox in the proximity of the proportional field tempts the user to modify the proportional field right by clicking on the checkbox but to actually edit the proportional field , user has to click on the edit icon beside the delete icon and then modify it. So ,I have added a image indicating green tick or red cross for either cases instead of the checkbox as on this screen :arrow_down: 

![Screenshot_2021-03-22-12-45-41-71_44eb2329bec141192ae3530735fe1d93](https://user-images.githubusercontent.com/53621853/112042649-c3f15000-8b6d-11eb-9710-950a6514a8cb.jpg)

After Fixing , this is how it looks : :arrow_down: 

![Screenshot_2021-03-23-00-19-56-65_44eb2329bec141192ae3530735fe1d93](https://user-images.githubusercontent.com/53621853/112042804-f4d18500-8b6d-11eb-9411-b5fc70c9c424.jpg)



Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.


