### PR TITLE
EditText validation added in the new payroll allocation bottomsheet

### DIFF
--- a/app/src/main/java/org/apache/fineract/ui/online/customers/customerpayroll/editcustomerpayroll/editpayrollbottomsheet/EditPayrollBottomSheet.kt
+++ b/app/src/main/java/org/apache/fineract/ui/online/customers/customerpayroll/editcustomerpayroll/editpayrollbottomsheet/EditPayrollBottomSheet.kt
@@ -45,6 +45,8 @@ class EditPayrollBottomSheet : BottomSheetDialogFragment() {
                 }
 
                 dismiss()
+            }else if(rootView.etAccount.text.isNullOrEmpty()){
+            rootView.etAccount.error = getString(R.string.account_field_cannot_be_empty)
             }
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -542,4 +542,5 @@
     <string name="please_wait_updating_group_status">"Updating group status, please wait... "</string>
     <string name="error_while_updating_group_status">Error while updating group status</string>
     <string name="error_while_creating_group">Error while creating group</string>
+    <string name="account_field_cannot_be_empty">Account field should not be left empty.</string>
 </resources>


### PR DESCRIPTION
Fixes [FINCN-307](https://issues.apache.org/jira/browse/FINCN-307)

Before fix : 

https://user-images.githubusercontent.com/53621853/112095555-b6b28080-8bc2-11eb-93df-256630263728.mp4

After fix : 

https://user-images.githubusercontent.com/53621853/112095572-bd40f800-8bc2-11eb-8334-87d486a92ece.mp4



Steps to reproduce: Customers page > Select any customer > go to payroll screen > click on edit icon > go to next step > on clicking Add FAB, if the user clicks Add without entering anything in Account field, nothing happens nor any feedback is given to the user.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.


