### PR TITLE
rv items made clickable in GroupList Fragment

### DIFF
--- a/app/src/main/res/layout/item_group.xml
+++ b/app/src/main/res/layout/item_group.xml
@@ -3,6 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/ll_group"
+    android:clickable="true"
+    android:foreground="?android:attr/selectableItemBackground"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical">


### PR DESCRIPTION
Fixes [FINCN-325](https://issues.apache.org/jira/browse/FINCN-325)

In all the listing fragments using recyclerView, the elements are made clickable but in the GroupList Fragment, it is not clickable. In order to maintain uniformity in the application, the recyclerView item should be made clickable.


https://user-images.githubusercontent.com/53621853/121808761-ac5eca80-cc77-11eb-88ea-0fad19ba7508.mp4




Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything.

- [x] If you have multiple commits please combine them into one commit by squashing them.


