### PR TITLE
Updated RestCountryAPI URL

### DIFF
--- a/app/src/main/java/org/apache/fineract/data/services/AnonymousService.java
+++ b/app/src/main/java/org/apache/fineract/data/services/AnonymousService.java
@@ -13,6 +13,6 @@ import retrofit2.http.GET;
  */
 public interface AnonymousService {
 
-    @GET("http://restcountries.eu/rest/v2/all?fields=name;alpha2Code;translations")
+    @GET("https://restcountries.com/v2/all?fields=name,alpha2Code,translations")
     Observable<List<Country>> getCountries();
 }


### PR DESCRIPTION
Fixes The Invalid Country Issue while creating a new customer 

Before and After Screenshots -
![image](https://user-images.githubusercontent.com/83168137/163053670-b83df385-7f00-4b93-8d0e-ef3bfa9ffc9d.png) ![image](https://user-images.githubusercontent.com/83168137/163048342-8ab51d93-6cfc-44b0-9a62-3acff90ccec5.png)

Summary - 
When creating a new customer and entering Customer's Address, all the countries were considered invalid as the URL of API fetching was outdated.
I have updated the URL keeping the required fields in mind.
New URL - https://restcountries.com/v2/all?fields=name,alpha2Code,translations